### PR TITLE
feat(session): scaffold session recording and summary

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core utilities for GymGuardian."""

--- a/src/core/paths.py
+++ b/src/core/paths.py
@@ -1,0 +1,13 @@
+"""Filesystem paths for GymGuardian."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+SESSIONS_DIR = PROJECT_ROOT / "sessions"
+
+ASSETS_DIR = PROJECT_ROOT / "assets"
+MODELS_DIR = ASSETS_DIR / "models"
+POSE_TASK_FILE = MODELS_DIR / "pose_landmarker_full.task"

--- a/src/session/__init__.py
+++ b/src/session/__init__.py
@@ -1,0 +1,1 @@
+"""Session recording and summary utilities."""

--- a/src/session/recorder.py
+++ b/src/session/recorder.py
@@ -1,0 +1,39 @@
+"""Session recording placeholder for MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import cv2
+
+
+@dataclass
+class SessionRecorder:
+    """Minimal recorder stub for later session video capture."""
+
+    output_dir: Path
+    fps: float
+    frame_size: tuple[int, int]
+
+    _writer: Optional[cv2.VideoWriter] = None
+
+    def start(self, filename: str) -> None:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = self.output_dir / filename
+        self._writer = cv2.VideoWriter(
+            str(output_path),
+            cv2.VideoWriter_fourcc(*"mp4v"),
+            self.fps,
+            self.frame_size,
+        )
+
+    def write(self, frame) -> None:
+        if self._writer:
+            self._writer.write(frame)
+
+    def stop(self) -> None:
+        if self._writer:
+            self._writer.release()
+            self._writer = None

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -1,0 +1,37 @@
+"""Session summary placeholder for MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class RepEvent:
+    timestamp: float
+    label: str
+    reason: str = ""
+
+
+@dataclass
+class SessionSummary:
+    started_at: datetime
+    rep_count: int = 0
+    bad_rep_count: int = 0
+    events: List[RepEvent] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "started_at": self.started_at.isoformat(),
+            "rep_count": self.rep_count,
+            "bad_rep_count": self.bad_rep_count,
+            "events": [
+                {
+                    "timestamp": event.timestamp,
+                    "label": event.label,
+                    "reason": event.reason,
+                }
+                for event in self.events
+            ],
+        }


### PR DESCRIPTION
- Added session module for recording workout sessions.
- Introduced video recorder stub and session summary data structures.
- Added centralised filesystem paths for session outputs.
- Session logic is scaffolded; recording will be wired in a follow-up commit.
- Issue: Closes #3 