### PR TITLE
feat: add squat rep counting and too-shallow detection

### DIFF
--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -1,4 +1,4 @@
-"""Basic squat state classification for MVP (Tasks Pose Landmarker result)."""
+"""Squat state classification and rep counting for MVP (Tasks Pose Landmarker result)."""
 
 from __future__ import annotations
 
@@ -88,3 +88,77 @@ def _angle_degrees(a, b, c) -> float:
 
     cos_angle = max(-1.0, min(1.0, dot / (mag_ba * mag_bc)))
     return math.degrees(math.acos(cos_angle))
+
+
+@dataclass(frozen=True)
+class RepCounterUpdate:
+    rep_started: bool = False
+    rep_completed: bool = False
+    is_bad: bool = False
+    reason: str = ""
+    min_knee_angle: Optional[float] = None
+
+
+class SquatRepCounter:
+    """Track squat reps and basic form errors (e.g., too shallow)."""
+
+    def __init__(self) -> None:
+        self.rep_count = 0
+        self.bad_rep_count = 0
+        self.last_rep_result = "none"
+        self._down_frames = 0
+        self._in_rep = False
+        self._rep_start_time = 0.0
+        self._min_knee_angle: Optional[float] = None
+
+    def update(self, squat_state: SquatState, timestamp: float) -> RepCounterUpdate:
+        if squat_state.label == "no_pose":
+            self._down_frames = 0
+            return RepCounterUpdate()
+
+        if squat_state.label == "down":
+            self._down_frames += 1
+            if squat_state.knee_angle is not None:
+                if self._min_knee_angle is None:
+                    self._min_knee_angle = squat_state.knee_angle
+                else:
+                    self._min_knee_angle = min(
+                        self._min_knee_angle, squat_state.knee_angle
+                    )
+
+            if not self._in_rep and self._down_frames >= SQUAT_CONFIG.down_hold_frames:
+                self._in_rep = True
+                self._rep_start_time = timestamp
+                return RepCounterUpdate(
+                    rep_started=True,
+                    min_knee_angle=self._min_knee_angle,
+                )
+        else:
+            self._down_frames = 0
+
+        if self._in_rep and squat_state.label == "standing":
+            if timestamp - self._rep_start_time >= SQUAT_CONFIG.min_rep_seconds:
+                min_angle = self._min_knee_angle
+                is_bad = (
+                    min_angle is None
+                    or min_angle > SQUAT_CONFIG.shallow_knee_angle
+                )
+                reason = "too_shallow" if is_bad else ""
+
+                self.rep_count += 1
+                if is_bad:
+                    self.bad_rep_count += 1
+
+                self.last_rep_result = "too_shallow" if is_bad else "ok"
+
+                self._in_rep = False
+                self._min_knee_angle = None
+
+                return RepCounterUpdate(
+                    rep_completed=True,
+                    is_bad=is_bad,
+                    reason=reason,
+                    min_knee_angle=min_angle,
+                )
+
+        return RepCounterUpdate()

--- a/src/app.py
+++ b/src/app.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+import time
+
 import cv2
 
-from analysis.squat import SquatStateAnalyzer
+from analysis.squat import SquatRepCounter, SquatStateAnalyzer
 from pose.detector import PoseDetector
+from session.summary import SessionSummary
 from ui.overlay import OverlayRenderer
 
 
@@ -21,7 +25,10 @@ def main() -> None:
 
     detector = PoseDetector()
     analyzer = SquatStateAnalyzer()
+    rep_counter = SquatRepCounter()
     overlay = OverlayRenderer()
+    summary = SessionSummary(started_at=datetime.now())
+    start_time = time.time()
 
     try:
         while True:
@@ -29,9 +36,21 @@ def main() -> None:
             if not ok:
                 break
 
+            timestamp = time.time()
             results = detector.process(frame)
             squat_state = analyzer.classify(results)
-            overlay.draw(frame, results, squat_state)
+            rep_update = rep_counter.update(squat_state, timestamp)
+
+            elapsed = timestamp - start_time
+            if rep_update.rep_started:
+                summary.record_rep_start(elapsed)
+            if rep_update.rep_completed:
+                summary.record_rep_complete(elapsed, reason=rep_update.reason)
+
+            summary.rep_count = rep_counter.rep_count
+            summary.bad_rep_count = rep_counter.bad_rep_count
+
+            overlay.draw(frame, results, squat_state, rep_counter)
 
             cv2.imshow("GymGuardian", frame)
             key = cv2.waitKey(1) & 0xFF

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -17,6 +17,9 @@ class PoseConfig:
 class SquatConfig:
     down_knee_angle: float = 100.0
     up_knee_angle: float = 160.0
+    shallow_knee_angle: float = 110.0
+    down_hold_frames: int = 6
+    min_rep_seconds: float = 0.6
 
 
 POSE_CONFIG = PoseConfig()

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -21,6 +21,15 @@ class SessionSummary:
     bad_rep_count: int = 0
     events: List[RepEvent] = field(default_factory=list)
 
+    def add_event(self, timestamp: float, label: str, reason: str = "") -> None:
+        self.events.append(RepEvent(timestamp=timestamp, label=label, reason=reason))
+
+    def record_rep_start(self, timestamp: float) -> None:
+        self.add_event(timestamp=timestamp, label="rep_start")
+
+    def record_rep_complete(self, timestamp: float, reason: str = "") -> None:
+        self.add_event(timestamp=timestamp, label="rep_complete", reason=reason)
+
     def to_dict(self) -> dict:
         return {
             "started_at": self.started_at.isoformat(),

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -6,7 +6,7 @@ import cv2
 
 
 class OverlayRenderer:
-    def draw(self, frame_bgr, results, squat_state) -> None:
+    def draw(self, frame_bgr, results, squat_state, rep_counter=None) -> None:
         # results.pose_landmarks is a list (per detected pose), each is list of landmarks
         if results and getattr(results, "pose_landmarks", None):
             if len(results.pose_landmarks) > 0:
@@ -19,7 +19,7 @@ class OverlayRenderer:
                     y = int(lm.y * h)
                     cv2.circle(frame_bgr, (x, y), 3, (0, 255, 0), -1)
 
-                # (Optional) simple “stick” connections can be added later.
+                # Optional simple stick connections can be added later.
                 # For MVP, keypoints are enough to confirm tracking works.
 
         label = f"State: {squat_state.label}"
@@ -36,3 +36,20 @@ class OverlayRenderer:
             2,
             cv2.LINE_AA,
         )
+
+        if rep_counter is not None:
+            rep_text = (
+                f"Reps: {rep_counter.rep_count} | "
+                f"Bad: {rep_counter.bad_rep_count} | "
+                f"Last: {rep_counter.last_rep_result}"
+            )
+            cv2.putText(
+                frame_bgr,
+                rep_text,
+                (20, 80),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.9,
+                (0, 255, 0),
+                2,
+                cv2.LINE_AA,
+            )


### PR DESCRIPTION
- Implemented squat rep counting using a simple state-based tracker.
- Added basic form error detection for shallow squats.
- Extended session summary with rep start and completion events.
- Updated overlay to show live rep statistics and last rep result.
- Added configurable thresholds for rep detection and depth checking.
- Issue: Closes #9