### PR TITLE
feat(session): persist session summary to disk

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ import time
 import cv2
 
 from analysis.squat import SquatRepCounter, SquatStateAnalyzer
+from core.paths import SESSIONS_DIR
 from pose.detector import PoseDetector
 from session.summary import SessionSummary
 from ui.overlay import OverlayRenderer
@@ -28,6 +29,7 @@ def main() -> None:
     rep_counter = SquatRepCounter()
     overlay = OverlayRenderer()
     summary = SessionSummary(started_at=datetime.now())
+    session_dir = SESSIONS_DIR / summary.started_at.strftime("%Y%m%d_%H%M%S")
     start_time = time.time()
 
     try:
@@ -57,9 +59,14 @@ def main() -> None:
             if key in (27, ord("q")):
                 break
     finally:
+        summary.rep_count = rep_counter.rep_count
+        summary.bad_rep_count = rep_counter.bad_rep_count
+        saved_path = summary.save(session_dir)
+
         detector.close()
         cap.release()
         cv2.destroyAllWindows()
+        print(f"Session summary saved: {saved_path}")
 
 
 if __name__ == "__main__":

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+import json
+from pathlib import Path
 from typing import List
 
 
@@ -44,3 +46,10 @@ class SessionSummary:
                 for event in self.events
             ],
         }
+
+    def save(self, output_dir: Path) -> Path:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / "summary.json"
+        with output_path.open("w", encoding="utf-8") as file:
+            json.dump(self.to_dict(), file, indent=2)
+        return output_path


### PR DESCRIPTION
- Added `SessionSummary.save()` to write `summary.json` to disk.
- Updated app to create a timestamped `sessions/<timestamp>/` folder and save the summary on exit.

- Closes #11