### PR TITLE
chore(repo): ignore sessions output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ models/*.onnx
 data/*.mp4
 data/*.avi
 assets/models/*.task
+
+sessions/


### PR DESCRIPTION
- What changed: ignore generated sessions outputs (`sessions/`)
- How to test: run app; confirm session folder/files don’t show in git status
- Evidence: `sessions/<timestamp>/summary.json` created but not tracked