### PR TITLE
feat: add dashboard and session browser

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,29 +6,50 @@ from datetime import datetime
 import time
 
 import cv2
+import numpy as np
 
 from analysis.squat import SquatRepCounter, SquatStateAnalyzer
 from core.paths import SESSIONS_DIR
 from pose.detector import PoseDetector
+from session.browser import (
+    list_recent_sessions,
+    open_session_folder,
+    open_session_video,
+)
 from session.recorder import SessionRecorder
 from session.summary import SessionSummary
 from ui.overlay import OverlayRenderer
 
 
-def main() -> None:
+WINDOW_NAME = "GymGuardian"
+FRAME_WIDTH = 1280
+FRAME_HEIGHT = 720
+STATE_DASHBOARD = "dashboard"
+STATE_SESSION = "session"
+STATE_BROWSE = "browse"
+UP_KEY = 2490368
+DOWN_KEY = 2621440
+
+
+def _blank_screen() -> np.ndarray:
+    return np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+
+
+def run_session(overlay: OverlayRenderer) -> None:
+    """Run one workout session and persist outputs on exit."""
     cap = cv2.VideoCapture(0)
     if not cap.isOpened():
-        raise RuntimeError("Could not open webcam at index 0.")
+        print("Warning: could not open webcam for session.")
+        return
 
     # Request 720p capture when supported by the camera.
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
-    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, FRAME_WIDTH)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT)
     cap.set(cv2.CAP_PROP_FPS, 30)
 
     detector = PoseDetector()
     analyzer = SquatStateAnalyzer()
     rep_counter = SquatRepCounter()
-    overlay = OverlayRenderer()
     summary = SessionSummary(started_at=datetime.now())
     session_dir = SESSIONS_DIR / summary.started_at.strftime("%Y%m%d_%H%M%S")
     recorder = SessionRecorder(session_dir)
@@ -64,7 +85,7 @@ def main() -> None:
             overlay.draw(frame, results, squat_state, rep_counter)
             recorder.write(frame)
 
-            cv2.imshow("GymGuardian", frame)
+            cv2.imshow(WINDOW_NAME, frame)
             key = cv2.waitKey(1) & 0xFF
             if key in (27, ord("q")):
                 break
@@ -76,10 +97,62 @@ def main() -> None:
 
         detector.close()
         cap.release()
-        cv2.destroyAllWindows()
+
         print(f"Session summary saved: {saved_path}")
         if recorder_started and recorder.output_path.exists():
             print(f"Session video path: {recorder.output_path}")
+
+
+def run_browser(overlay: OverlayRenderer) -> None:
+    """Render session browser and handle navigation/actions."""
+    sessions = list_recent_sessions(SESSIONS_DIR)
+    selected_index = 0
+
+    while True:
+        frame = _blank_screen()
+        overlay.draw_browser(frame, sessions, selected_index)
+        cv2.imshow(WINDOW_NAME, frame)
+
+        key = cv2.waitKeyEx(0)
+        if key == 8:  # Backspace
+            return
+        if key == UP_KEY and sessions:
+            selected_index = max(0, selected_index - 1)
+        elif key == DOWN_KEY and sessions:
+            selected_index = min(len(sessions) - 1, selected_index + 1)
+        elif key in (ord("p"), ord("P")) and sessions:
+            open_session_video(sessions[selected_index])
+        elif key in (ord("o"), ord("O")) and sessions:
+            open_session_folder(sessions[selected_index])
+
+
+def main() -> None:
+    overlay = OverlayRenderer()
+    state = STATE_DASHBOARD
+    cv2.namedWindow(WINDOW_NAME)
+
+    try:
+        while True:
+            if state == STATE_DASHBOARD:
+                frame = _blank_screen()
+                overlay.draw_dashboard(frame)
+                cv2.imshow(WINDOW_NAME, frame)
+                key = cv2.waitKeyEx(0)
+
+                if key in (ord("s"), ord("S")):
+                    state = STATE_SESSION
+                elif key in (ord("b"), ord("B")):
+                    state = STATE_BROWSE
+                elif key in (ord("q"), ord("Q"), 27):
+                    break
+            elif state == STATE_SESSION:
+                run_session(overlay)
+                state = STATE_DASHBOARD
+            elif state == STATE_BROWSE:
+                run_browser(overlay)
+                state = STATE_DASHBOARD
+    finally:
+        cv2.destroyAllWindows()
 
 
 if __name__ == "__main__":

--- a/src/session/browser.py
+++ b/src/session/browser.py
@@ -1,0 +1,84 @@
+"""Session browser helpers for loading and opening saved sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SessionBrowserItem:
+    """Represents one saved session folder and its metadata."""
+
+    folder_name: str
+    folder_path: Path
+    video_path: Path
+    summary_path: Path
+    rep_count: Optional[int]
+    bad_rep_count: Optional[int]
+
+
+def list_recent_sessions(sessions_dir: Path, limit: int = 30) -> list[SessionBrowserItem]:
+    """Return saved sessions sorted newest-first by timestamp folder name."""
+    if not sessions_dir.exists():
+        return []
+
+    folders = [path for path in sessions_dir.iterdir() if path.is_dir()]
+    folders.sort(key=lambda path: path.name, reverse=True)
+
+    items: list[SessionBrowserItem] = []
+    for folder in folders[:limit]:
+        summary_path = folder / "summary.json"
+        video_path = folder / "session.mp4"
+        rep_count = None
+        bad_rep_count = None
+
+        if summary_path.exists():
+            try:
+                with summary_path.open("r", encoding="utf-8") as file:
+                    data = json.load(file)
+                rep_count = _safe_int(data.get("rep_count"))
+                bad_rep_count = _safe_int(data.get("bad_rep_count"))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        items.append(
+            SessionBrowserItem(
+                folder_name=folder.name,
+                folder_path=folder,
+                video_path=video_path,
+                summary_path=summary_path,
+                rep_count=rep_count,
+                bad_rep_count=bad_rep_count,
+            )
+        )
+
+    return items
+
+
+def open_session_video(session: SessionBrowserItem) -> None:
+    """Open a session video in the default media player on Windows."""
+    if not session.video_path.exists():
+        print(f"Warning: session video not found at {session.video_path}")
+        return
+
+    os.startfile(str(session.video_path))
+
+
+def open_session_folder(session: SessionBrowserItem) -> None:
+    """Open the session folder in Windows Explorer."""
+    if not session.folder_path.exists():
+        print(f"Warning: session folder not found at {session.folder_path}")
+        return
+
+    os.startfile(str(session.folder_path))
+
+
+def _safe_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -1,4 +1,4 @@
-"""Overlay rendering for pose landmarks and squat state (Tasks API result)."""
+"""Overlay rendering for workout, dashboard, and browser screens."""
 
 from __future__ import annotations
 
@@ -13,14 +13,10 @@ class OverlayRenderer:
                 landmarks = results.pose_landmarks[0]
                 h, w = frame_bgr.shape[:2]
 
-                # Draw keypoints as circles
                 for lm in landmarks:
                     x = int(lm.x * w)
                     y = int(lm.y * h)
                     cv2.circle(frame_bgr, (x, y), 3, (0, 255, 0), -1)
-
-                # Optional simple stick connections can be added later.
-                # For MVP, keypoints are enough to confirm tracking works.
 
         label = f"State: {squat_state.label}"
         if squat_state.knee_angle is not None:
@@ -53,3 +49,83 @@ class OverlayRenderer:
                 2,
                 cv2.LINE_AA,
             )
+
+    def draw_dashboard(self, frame_bgr) -> None:
+        self._put_heading(frame_bgr, "GymGuardian Dashboard")
+        lines = [
+            "S - Start Session",
+            "B - Browse Sessions",
+            "Q / Esc - Quit",
+        ]
+        self._put_lines(frame_bgr, lines, start_y=170)
+
+    def draw_browser(self, frame_bgr, sessions, selected_index: int) -> None:
+        self._put_heading(frame_bgr, "Session Browser")
+        instructions = [
+            "Up/Down - Move selection",
+            "P - Play session.mp4",
+            "O - Open session folder",
+            "Backspace - Return to Dashboard",
+        ]
+        self._put_lines(frame_bgr, instructions, start_y=110, line_height=28, scale=0.7)
+
+        if not sessions:
+            self._put_lines(frame_bgr, ["No sessions found in /sessions"], start_y=260)
+            return
+
+        start = max(0, selected_index - 5)
+        end = min(len(sessions), start + 10)
+        row_y = 260
+        for idx in range(start, end):
+            item = sessions[idx]
+            selected = idx == selected_index
+            prefix = ">" if selected else " "
+            reps = "?" if item.rep_count is None else str(item.rep_count)
+            bad = "?" if item.bad_rep_count is None else str(item.bad_rep_count)
+            text = f"{prefix} {item.folder_name} | reps: {reps} | bad: {bad}"
+            color = (0, 255, 255) if selected else (200, 200, 200)
+            cv2.putText(
+                frame_bgr,
+                text,
+                (30, row_y),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.65,
+                color,
+                2,
+                cv2.LINE_AA,
+            )
+            row_y += 36
+
+    def _put_heading(self, frame_bgr, text: str) -> None:
+        cv2.putText(
+            frame_bgr,
+            text,
+            (20, 50),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1.1,
+            (0, 255, 0),
+            2,
+            cv2.LINE_AA,
+        )
+
+    def _put_lines(
+        self,
+        frame_bgr,
+        lines: list[str],
+        start_y: int,
+        line_height: int = 34,
+        scale: float = 0.8,
+    ) -> None:
+        y = start_y
+        for line in lines:
+            cv2.putText(
+                frame_bgr,
+                line,
+                (30, y),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                scale,
+                (200, 200, 200),
+                2,
+                cv2.LINE_AA,
+            )
+            y += line_height


### PR DESCRIPTION
- **State Machine:** Refactored `app.py` to support persistent states (Dashboard, Session, Browse).
- **Dashboard:** Added a main menu overlay to start sessions or view history without restarting the app.
- **Session Browser:** Added a list view of recent sessions (parsing `summary.json` for stats).
- **External Actions:** Added support for opening session videos (`P`) and folders (`O`) using the OS default handlers.

- Issue: Closes #16