### PR TITLE
feat: add debug overlay toggle for testing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ import cv2
 import numpy as np
 
 from analysis.squat import SquatRepCounter, SquatStateAnalyzer
+from core.config import SQUAT_CONFIG
 from core.paths import SESSIONS_DIR
 from pose.detector import PoseDetector
 from session.browser import (
@@ -55,6 +56,9 @@ def run_session(overlay: OverlayRenderer) -> None:
     recorder = SessionRecorder(session_dir)
     recorder_started = False
     start_time = time.time()
+    debug_enabled = False
+    fps_estimate = 0.0
+    previous_frame_time = 0.0
 
     try:
         while True:
@@ -69,6 +73,13 @@ def run_session(overlay: OverlayRenderer) -> None:
                 recorder_started = True
 
             timestamp = time.time()
+            if previous_frame_time > 0:
+                delta = timestamp - previous_frame_time
+                if delta > 0:
+                    instant_fps = 1.0 / delta
+                    fps_estimate = instant_fps if fps_estimate == 0 else (0.9 * fps_estimate + 0.1 * instant_fps)
+            previous_frame_time = timestamp
+
             results = detector.process(frame)
             squat_state = analyzer.classify(results)
             rep_update = rep_counter.update(squat_state, timestamp)
@@ -83,12 +94,31 @@ def run_session(overlay: OverlayRenderer) -> None:
             summary.bad_rep_count = rep_counter.bad_rep_count
 
             overlay.draw(frame, results, squat_state, rep_counter)
+            if debug_enabled:
+                pose_detected = bool(
+                    results
+                    and getattr(results, "pose_landmarks", None)
+                    and len(results.pose_landmarks) > 0
+                )
+                debug_info = {
+                    "fps": fps_estimate,
+                    "pose_detected": pose_detected,
+                    "knee_angle": squat_state.knee_angle,
+                    "down_knee_angle": SQUAT_CONFIG.down_knee_angle,
+                    "up_knee_angle": SQUAT_CONFIG.up_knee_angle,
+                    "shallow_knee_angle": SQUAT_CONFIG.shallow_knee_angle,
+                    "down_hold_frames": SQUAT_CONFIG.down_hold_frames,
+                    "min_rep_seconds": SQUAT_CONFIG.min_rep_seconds,
+                }
+                overlay.draw_debug(frame, debug_info)
             recorder.write(frame)
 
             cv2.imshow(WINDOW_NAME, frame)
             key = cv2.waitKey(1) & 0xFF
             if key in (27, ord("q")):
                 break
+            if key in (ord("d"), ord("D")):
+                debug_enabled = not debug_enabled
     finally:
         summary.rep_count = rep_counter.rep_count
         summary.bad_rep_count = rep_counter.bad_rep_count

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -96,6 +96,63 @@ class OverlayRenderer:
             )
             row_y += 36
 
+    def draw_debug(self, frame_bgr, debug_info: dict) -> None:
+        lines = [
+            "DEBUG (D to toggle)",
+            f"FPS: {debug_info.get('fps', 0.0):.1f}",
+            f"Pose detected: {'yes' if debug_info.get('pose_detected') else 'no'}",
+        ]
+
+        knee_angle = debug_info.get("knee_angle")
+        if knee_angle is None:
+            lines.append("Knee angle: n/a")
+        else:
+            lines.append(f"Knee angle: {knee_angle:.1f}")
+
+        lines.extend(
+            [
+                f"down_knee_angle: {debug_info.get('down_knee_angle')}",
+                f"up_knee_angle: {debug_info.get('up_knee_angle')}",
+                f"shallow_knee_angle: {debug_info.get('shallow_knee_angle')}",
+                f"down_hold_frames: {debug_info.get('down_hold_frames')}",
+                f"min_rep_seconds: {debug_info.get('min_rep_seconds')}",
+            ]
+        )
+
+        panel_x = 20
+        panel_y = 110
+        line_height = 24
+        panel_w = 440
+        panel_h = 20 + line_height * len(lines)
+        cv2.rectangle(
+            frame_bgr,
+            (panel_x, panel_y),
+            (panel_x + panel_w, panel_y + panel_h),
+            (20, 20, 20),
+            -1,
+        )
+        cv2.rectangle(
+            frame_bgr,
+            (panel_x, panel_y),
+            (panel_x + panel_w, panel_y + panel_h),
+            (0, 180, 255),
+            2,
+        )
+
+        y = panel_y + 24
+        for line in lines:
+            cv2.putText(
+                frame_bgr,
+                line,
+                (panel_x + 10, y),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.6,
+                (235, 235, 235),
+                1,
+                cv2.LINE_AA,
+            )
+            y += line_height
+
     def _put_heading(self, frame_bgr, text: str) -> None:
         cv2.putText(
             frame_bgr,


### PR DESCRIPTION
Added a diagnostic overlay to assist with the Testing & Evaluation phase.
- **Toggle:** Press 'D' during a session.
- **Metrics:** Shows real-time FPS, detection confidence, and knee angles.
- **Config:** Displays current thresholds to verify settings during test runs.

- Issue : Closes #18