### PR TITLE
fix: correct shallow squat detection and bad rep classification

### DIFF
--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -100,33 +100,49 @@ class RepCounterUpdate:
 
 
 class SquatRepCounter:
-    """Track squat reps and basic form errors (e.g., too shallow)."""
+    """Track squat reps separately from depth quality checks."""
 
     def __init__(self) -> None:
         self.rep_count = 0
         self.bad_rep_count = 0
         self.last_rep_result = "none"
-        self._down_frames = 0
+        self._bottom_frames = 0
         self._in_rep = False
+        self._ready_for_rep = False
         self._rep_start_time = 0.0
         self._min_knee_angle: Optional[float] = None
 
     def update(self, squat_state: SquatState, timestamp: float) -> RepCounterUpdate:
         if squat_state.label == "no_pose":
-            self._down_frames = 0
+            self._bottom_frames = 0
             return RepCounterUpdate()
 
-        if squat_state.label == "down":
-            self._down_frames += 1
-            if squat_state.knee_angle is not None:
-                if self._min_knee_angle is None:
-                    self._min_knee_angle = squat_state.knee_angle
-                else:
-                    self._min_knee_angle = min(
-                        self._min_knee_angle, squat_state.knee_angle
-                    )
+        angle = squat_state.knee_angle
+        if angle is None:
+            self._bottom_frames = 0
+            return RepCounterUpdate()
 
-            if not self._in_rep and self._down_frames >= SQUAT_CONFIG.down_hold_frames:
+        if self._in_rep:
+            self._update_min_knee_angle(angle)
+            if timestamp - self._rep_start_time >= SQUAT_CONFIG.min_rep_seconds:
+                if angle >= SQUAT_CONFIG.up_knee_angle:
+                    return self._complete_rep()
+
+            return RepCounterUpdate()
+
+        if angle >= SQUAT_CONFIG.up_knee_angle:
+            self._ready_for_rep = True
+            self._bottom_frames = 0
+            self._min_knee_angle = None
+            return RepCounterUpdate()
+
+        if not self._ready_for_rep:
+            return RepCounterUpdate()
+
+        if angle <= SQUAT_CONFIG.rep_bottom_knee_angle:
+            self._bottom_frames += 1
+            self._update_min_knee_angle(angle)
+            if self._bottom_frames >= SQUAT_CONFIG.down_hold_frames:
                 self._in_rep = True
                 self._rep_start_time = timestamp
                 return RepCounterUpdate(
@@ -134,31 +150,35 @@ class SquatRepCounter:
                     min_knee_angle=self._min_knee_angle,
                 )
         else:
-            self._down_frames = 0
-
-        if self._in_rep and squat_state.label == "standing":
-            if timestamp - self._rep_start_time >= SQUAT_CONFIG.min_rep_seconds:
-                min_angle = self._min_knee_angle
-                is_bad = (
-                    min_angle is None
-                    or min_angle > SQUAT_CONFIG.shallow_knee_angle
-                )
-                reason = "too_shallow" if is_bad else ""
-
-                self.rep_count += 1
-                if is_bad:
-                    self.bad_rep_count += 1
-
-                self.last_rep_result = "too_shallow" if is_bad else "ok"
-
-                self._in_rep = False
-                self._min_knee_angle = None
-
-                return RepCounterUpdate(
-                    rep_completed=True,
-                    is_bad=is_bad,
-                    reason=reason,
-                    min_knee_angle=min_angle,
-                )
+            self._bottom_frames = 0
 
         return RepCounterUpdate()
+
+    def _update_min_knee_angle(self, angle: float) -> None:
+        if self._min_knee_angle is None:
+            self._min_knee_angle = angle
+        else:
+            self._min_knee_angle = min(self._min_knee_angle, angle)
+
+    def _complete_rep(self) -> RepCounterUpdate:
+        min_angle = self._min_knee_angle
+        is_bad = min_angle is None or min_angle > SQUAT_CONFIG.shallow_knee_angle
+        reason = "too_shallow" if is_bad else ""
+
+        self.rep_count += 1
+        if is_bad:
+            self.bad_rep_count += 1
+
+        self.last_rep_result = "too_shallow" if is_bad else "ok"
+        self._bottom_frames = 0
+        self._in_rep = False
+        self._ready_for_rep = True
+        self._rep_start_time = 0.0
+        self._min_knee_angle = None
+
+        return RepCounterUpdate(
+            rep_completed=True,
+            is_bad=is_bad,
+            reason=reason,
+            min_knee_angle=min_angle,
+        )

--- a/src/app.py
+++ b/src/app.py
@@ -77,7 +77,11 @@ def run_session(overlay: OverlayRenderer) -> None:
                 delta = timestamp - previous_frame_time
                 if delta > 0:
                     instant_fps = 1.0 / delta
-                    fps_estimate = instant_fps if fps_estimate == 0 else (0.9 * fps_estimate + 0.1 * instant_fps)
+                    fps_estimate = (
+                        instant_fps
+                        if fps_estimate == 0
+                        else (0.9 * fps_estimate + 0.1 * instant_fps)
+                    )
             previous_frame_time = timestamp
 
             results = detector.process(frame)
@@ -106,6 +110,7 @@ def run_session(overlay: OverlayRenderer) -> None:
                     "knee_angle": squat_state.knee_angle,
                     "down_knee_angle": SQUAT_CONFIG.down_knee_angle,
                     "up_knee_angle": SQUAT_CONFIG.up_knee_angle,
+                    "rep_bottom_knee_angle": SQUAT_CONFIG.rep_bottom_knee_angle,
                     "shallow_knee_angle": SQUAT_CONFIG.shallow_knee_angle,
                     "down_hold_frames": SQUAT_CONFIG.down_hold_frames,
                     "min_rep_seconds": SQUAT_CONFIG.min_rep_seconds,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -17,6 +17,7 @@ class PoseConfig:
 class SquatConfig:
     down_knee_angle: float = 100.0
     up_knee_angle: float = 160.0
+    rep_bottom_knee_angle: float = 140.0
     shallow_knee_angle: float = 110.0
     down_hold_frames: int = 6
     min_rep_seconds: float = 0.6

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -113,6 +113,7 @@ class OverlayRenderer:
             [
                 f"down_knee_angle: {debug_info.get('down_knee_angle')}",
                 f"up_knee_angle: {debug_info.get('up_knee_angle')}",
+                f"rep_bottom_knee_angle: {debug_info.get('rep_bottom_knee_angle')}",
                 f"shallow_knee_angle: {debug_info.get('shallow_knee_angle')}",
                 f"down_hold_frames: {debug_info.get('down_hold_frames')}",
                 f"min_rep_seconds: {debug_info.get('min_rep_seconds')}",


### PR DESCRIPTION
Closes #24 

## What changed
- Decoupled squat rep cycle detection from depth validation
- Counted shallow squats as completed reps when movement cycle is valid
- Added proper classification of shallow squats as bad reps ("too_shallow")
- Tuned thresholds in config for more consistent detection
- Updated overlay and app logic to reflect accurate rep and bad rep counts

## How to test
1. Perform 5 correct squats  
   Expected: rep_count = 5, bad_rep_count = 0  

2. Perform 5 shallow squats  
   Expected: rep_count = 5, bad_rep_count = 5  

3. Perform mixed squats (e.g., 5 correct + 5 shallow)  
   Expected: rep_count = 10, bad_rep_count = 5  

4. Verify summary.json:
   - rep_count matches total reps
   - bad_rep_count reflects shallow reps
   - "too_shallow" reason is recorded for bad reps

## Evidence
- Manual testing confirms accurate rep counting across correct, shallow, and mixed scenarios
- Previous issue where shallow reps were not counted or flagged has been resolved

## Result
This resolves a key limitation identified during evaluation and improves the reliability of rep classification.