### PR TITLE
feat: improve real-time corrective feedback messaging

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -30,10 +30,31 @@ STATE_SESSION = "session"
 STATE_BROWSE = "browse"
 UP_KEY = 2490368
 DOWN_KEY = 2621440
+FEEDBACK_HOLD_SECONDS = 2.0
 
 
 def _blank_screen() -> np.ndarray:
     return np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+
+
+def _current_feedback(
+    squat_state,
+    feedback_message: str | None,
+    feedback_level: str,
+    feedback_until: float,
+    timestamp: float,
+) -> tuple[str | None, str]:
+    if feedback_message and timestamp <= feedback_until:
+        return feedback_message, feedback_level
+
+    angle = squat_state.knee_angle
+    if (
+        angle is not None
+        and SQUAT_CONFIG.shallow_knee_angle < angle <= SQUAT_CONFIG.rep_bottom_knee_angle
+    ):
+        return "Go deeper", "warning"
+
+    return None, "info"
 
 
 def run_session(overlay: OverlayRenderer) -> None:
@@ -59,6 +80,9 @@ def run_session(overlay: OverlayRenderer) -> None:
     debug_enabled = False
     fps_estimate = 0.0
     previous_frame_time = 0.0
+    feedback_message: str | None = None
+    feedback_level = "info"
+    feedback_until = 0.0
 
     try:
         while True:
@@ -93,11 +117,32 @@ def run_session(overlay: OverlayRenderer) -> None:
                 summary.record_rep_start(elapsed)
             if rep_update.rep_completed:
                 summary.record_rep_complete(elapsed, reason=rep_update.reason)
+                if rep_update.reason == "too_shallow":
+                    feedback_message = "Bad rep: too shallow"
+                    feedback_level = "bad"
+                else:
+                    feedback_message = "Rep accepted"
+                    feedback_level = "ok"
+                feedback_until = timestamp + FEEDBACK_HOLD_SECONDS
 
             summary.rep_count = rep_counter.rep_count
             summary.bad_rep_count = rep_counter.bad_rep_count
 
-            overlay.draw(frame, results, squat_state, rep_counter)
+            feedback_text, feedback_kind = _current_feedback(
+                squat_state,
+                feedback_message,
+                feedback_level,
+                feedback_until,
+                timestamp,
+            )
+            overlay.draw(
+                frame,
+                results,
+                squat_state,
+                rep_counter,
+                feedback_text,
+                feedback_kind,
+            )
             if debug_enabled:
                 pose_detected = bool(
                     results

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -6,7 +6,15 @@ import cv2
 
 
 class OverlayRenderer:
-    def draw(self, frame_bgr, results, squat_state, rep_counter=None) -> None:
+    def draw(
+        self,
+        frame_bgr,
+        results,
+        squat_state,
+        rep_counter=None,
+        feedback_message: str | None = None,
+        feedback_level: str = "info",
+    ) -> None:
         # results.pose_landmarks is a list (per detected pose), each is list of landmarks
         if results and getattr(results, "pose_landmarks", None):
             if len(results.pose_landmarks) > 0:
@@ -49,6 +57,9 @@ class OverlayRenderer:
                 2,
                 cv2.LINE_AA,
             )
+
+        if feedback_message:
+            self._draw_feedback(frame_bgr, feedback_message, feedback_level)
 
     def draw_dashboard(self, frame_bgr) -> None:
         self._put_heading(frame_bgr, "GymGuardian Dashboard")
@@ -153,6 +164,54 @@ class OverlayRenderer:
                 cv2.LINE_AA,
             )
             y += line_height
+
+    def _draw_feedback(
+        self, frame_bgr, message: str, feedback_level: str = "info"
+    ) -> None:
+        colors = {
+            "ok": (0, 220, 0),
+            "bad": (0, 0, 255),
+            "warning": (0, 210, 255),
+            "info": (235, 235, 235),
+        }
+        color = colors.get(feedback_level, colors["info"])
+        font = cv2.FONT_HERSHEY_SIMPLEX
+        scale = 1.0
+        thickness = 2
+        text_size, _ = cv2.getTextSize(message, font, scale, thickness)
+        text_w, text_h = text_size
+        _, frame_w = frame_bgr.shape[:2]
+        pad_x = 16
+        pad_y = 12
+        panel_x = max(20, frame_w - text_w - (pad_x * 2) - 24)
+        panel_y = 24
+        panel_w = text_w + (pad_x * 2)
+        panel_h = text_h + (pad_y * 2)
+
+        cv2.rectangle(
+            frame_bgr,
+            (panel_x, panel_y),
+            (panel_x + panel_w, panel_y + panel_h),
+            (20, 20, 20),
+            -1,
+        )
+        cv2.rectangle(
+            frame_bgr,
+            (panel_x, panel_y),
+            (panel_x + panel_w, panel_y + panel_h),
+            color,
+            2,
+        )
+        cv2.putText(
+            frame_bgr,
+            message,
+            (panel_x + pad_x, panel_y + pad_y + text_h),
+            font,
+            scale,
+            color,
+            thickness,
+            cv2.LINE_AA,
+        )
 
     def _put_heading(self, frame_bgr, text: str) -> None:
         cv2.putText(


### PR DESCRIPTION
Closes Issue #28 

What changed:
- Added clearer user-facing corrective feedback messages during workout sessions
- Improved overlay messaging to show accepted reps and shallow-rep guidance/results
- Kept existing counting, recording, summary, and browser behavior unchanged

How to run/test:
- Run python src/app.py
- Start a session
- Perform both proper and shallow squats
- Verify that the overlay shows clearer messages such as accepted rep feedback and shallow-depth guidance

Evidence:
- Manually tested with correct squats, shallow squats, and mixed sets after the shallow-detection fix
- Rep counts and bad rep counts continue to behave correctly