### PR TITLE
feat: add analytical dashboard for session insights

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ctypes
+from ctypes import wintypes
 from datetime import datetime
+import os
 import time
 
 import cv2
@@ -33,10 +36,101 @@ STATE_ANALYTICS = "analytics"
 UP_KEY = 2490368
 DOWN_KEY = 2621440
 FEEDBACK_HOLD_SECONDS = 2.0
+SW_MAXIMIZE = 3
+
+_WINDOW_MAXIMIZED = False
+
+
+def _get_window_client_size(window_name: str) -> tuple[int, int] | None:
+    """Return the drawable client area for the app window."""
+    if os.name == "nt":
+        hwnd = ctypes.windll.user32.FindWindowW(None, window_name)
+        if hwnd:
+            rect = wintypes.RECT()
+            if ctypes.windll.user32.GetClientRect(hwnd, ctypes.byref(rect)):
+                window_w = rect.right - rect.left
+                window_h = rect.bottom - rect.top
+                if window_w > 0 and window_h > 0:
+                    return window_w, window_h
+
+    try:
+        _, _, window_w, window_h = cv2.getWindowImageRect(window_name)
+        if window_w > 0 and window_h > 0:
+            return window_w, window_h
+    except cv2.error:
+        pass
+
+    return None
 
 
 def _blank_screen() -> np.ndarray:
-    return np.zeros((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+    window_size = _get_window_client_size(WINDOW_NAME)
+    if window_size is not None:
+        window_w, window_h = window_size
+        canvas = np.empty((window_h, window_w, 3), dtype=np.uint8)
+        canvas[:] = (15, 15, 15)
+        return canvas
+
+    canvas = np.empty((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
+    canvas[:] = (15, 15, 15)
+    return canvas
+
+
+def _maximize_window(window_name: str) -> None:
+    """Start the app maximized while preserving standard OS window controls."""
+    if os.name != "nt":
+        return
+
+    try:
+        hwnd = ctypes.windll.user32.FindWindowW(None, window_name)
+        if hwnd:
+            ctypes.windll.user32.ShowWindow(hwnd, SW_MAXIMIZE)
+    except Exception:
+        # Fall back to the default OpenCV window behavior if maximize fails.
+        return
+
+
+def _fit_frame_to_window(window_name: str, frame: np.ndarray) -> np.ndarray:
+    """Letterbox frames so window resizing never stretches the content."""
+    window_size = _get_window_client_size(window_name)
+    if window_size is None:
+        return frame
+
+    window_w, window_h = window_size
+
+    frame_h, frame_w = frame.shape[:2]
+    scale = min(window_w / frame_w, window_h / frame_h)
+    if scale <= 0:
+        return frame
+
+    target_w = max(1, int(frame_w * scale))
+    target_h = max(1, int(frame_h * scale))
+    if (
+        target_w == frame_w
+        and target_h == frame_h
+        and window_w == frame_w
+        and window_h == frame_h
+    ):
+        return frame
+
+    resized = cv2.resize(frame, (target_w, target_h), interpolation=cv2.INTER_LINEAR)
+    canvas = np.empty((window_h, window_w, 3), dtype=frame.dtype)
+    canvas[:] = (15, 15, 15)
+    x_offset = (window_w - target_w) // 2
+    y_offset = (window_h - target_h) // 2
+    canvas[y_offset:y_offset + target_h, x_offset:x_offset + target_w] = resized
+    return canvas
+
+
+def _show_frame(window_name: str, frame: np.ndarray) -> None:
+    """Display a frame with aspect-preserving scaling and maximize once on startup."""
+    global _WINDOW_MAXIMIZED
+
+    cv2.imshow(window_name, _fit_frame_to_window(window_name, frame))
+
+    if not _WINDOW_MAXIMIZED:
+        _maximize_window(window_name)
+        _WINDOW_MAXIMIZED = True
 
 
 def _current_feedback(
@@ -114,11 +208,16 @@ def run_session(overlay: OverlayRenderer) -> None:
             squat_state = analyzer.classify(results)
             rep_update = rep_counter.update(squat_state, timestamp)
 
+            if squat_state.knee_angle is not None:
+                summary.add_knee_angle(squat_state.knee_angle)
+
             elapsed = timestamp - start_time
             if rep_update.rep_started:
                 summary.record_rep_start(elapsed)
             if rep_update.rep_completed:
                 summary.record_rep_complete(elapsed, reason=rep_update.reason)
+                if rep_update.reason:
+                    summary.record_issue(rep_update.reason)
                 if rep_update.reason == "too_shallow":
                     feedback_message = "Bad rep: too shallow"
                     feedback_level = "bad"
@@ -165,9 +264,9 @@ def run_session(overlay: OverlayRenderer) -> None:
                 overlay.draw_debug(frame, debug_info)
             recorder.write(frame)
 
-            cv2.imshow(WINDOW_NAME, frame)
+            _show_frame(WINDOW_NAME, frame)
             key = cv2.waitKey(1) & 0xFF
-            if key in (27, ord("q")):
+            if key == 27:
                 break
             if key in (ord("d"), ord("D")):
                 debug_enabled = not debug_enabled
@@ -193,10 +292,10 @@ def run_browser(overlay: OverlayRenderer) -> None:
     while True:
         frame = _blank_screen()
         overlay.draw_browser(frame, sessions, selected_index)
-        cv2.imshow(WINDOW_NAME, frame)
+        _show_frame(WINDOW_NAME, frame)
 
         key = cv2.waitKeyEx(0)
-        if key == 8:  # Backspace
+        if key == 27:
             return
         if key == UP_KEY and sessions:
             selected_index = max(0, selected_index - 1)
@@ -215,10 +314,10 @@ def run_analytics(overlay: OverlayRenderer) -> None:
     while True:
         frame = _blank_screen()
         overlay.draw_analytics(frame, snapshot)
-        cv2.imshow(WINDOW_NAME, frame)
+        _show_frame(WINDOW_NAME, frame)
 
         key = cv2.waitKeyEx(0)
-        if key in (8, 27):  # Backspace / Esc
+        if key == 27:
             return
         if key in (ord("r"), ord("R")):
             snapshot = load_analytics_snapshot(SESSIONS_DIR)
@@ -227,14 +326,15 @@ def run_analytics(overlay: OverlayRenderer) -> None:
 def main() -> None:
     overlay = OverlayRenderer()
     state = STATE_DASHBOARD
-    cv2.namedWindow(WINDOW_NAME)
+    cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
+    cv2.resizeWindow(WINDOW_NAME, FRAME_WIDTH, FRAME_HEIGHT)
 
     try:
         while True:
             if state == STATE_DASHBOARD:
                 frame = _blank_screen()
                 overlay.draw_dashboard(frame)
-                cv2.imshow(WINDOW_NAME, frame)
+                _show_frame(WINDOW_NAME, frame)
                 key = cv2.waitKeyEx(0)
 
                 if key in (ord("s"), ord("S")):
@@ -243,7 +343,7 @@ def main() -> None:
                     state = STATE_BROWSE
                 elif key in (ord("a"), ord("A")):
                     state = STATE_ANALYTICS
-                elif key in (ord("q"), ord("Q"), 27):
+                elif key == 27:
                     break
             elif state == STATE_SESSION:
                 run_session(overlay)

--- a/src/app.py
+++ b/src/app.py
@@ -14,6 +14,7 @@ from core.paths import SESSIONS_DIR
 from pose.detector import PoseDetector
 from session.browser import (
     list_recent_sessions,
+    load_analytics_snapshot,
     open_session_folder,
     open_session_video,
 )
@@ -28,6 +29,7 @@ FRAME_HEIGHT = 720
 STATE_DASHBOARD = "dashboard"
 STATE_SESSION = "session"
 STATE_BROWSE = "browse"
+STATE_ANALYTICS = "analytics"
 UP_KEY = 2490368
 DOWN_KEY = 2621440
 FEEDBACK_HOLD_SECONDS = 2.0
@@ -206,6 +208,22 @@ def run_browser(overlay: OverlayRenderer) -> None:
             open_session_folder(sessions[selected_index])
 
 
+def run_analytics(overlay: OverlayRenderer) -> None:
+    """Render lightweight session analytics using saved summaries."""
+    snapshot = load_analytics_snapshot(SESSIONS_DIR)
+
+    while True:
+        frame = _blank_screen()
+        overlay.draw_analytics(frame, snapshot)
+        cv2.imshow(WINDOW_NAME, frame)
+
+        key = cv2.waitKeyEx(0)
+        if key in (8, 27):  # Backspace / Esc
+            return
+        if key in (ord("r"), ord("R")):
+            snapshot = load_analytics_snapshot(SESSIONS_DIR)
+
+
 def main() -> None:
     overlay = OverlayRenderer()
     state = STATE_DASHBOARD
@@ -223,6 +241,8 @@ def main() -> None:
                     state = STATE_SESSION
                 elif key in (ord("b"), ord("B")):
                     state = STATE_BROWSE
+                elif key in (ord("a"), ord("A")):
+                    state = STATE_ANALYTICS
                 elif key in (ord("q"), ord("Q"), 27):
                     break
             elif state == STATE_SESSION:
@@ -230,6 +250,9 @@ def main() -> None:
                 state = STATE_DASHBOARD
             elif state == STATE_BROWSE:
                 run_browser(overlay)
+                state = STATE_DASHBOARD
+            elif state == STATE_ANALYTICS:
+                run_analytics(overlay)
                 state = STATE_DASHBOARD
     finally:
         cv2.destroyAllWindows()

--- a/src/session/browser.py
+++ b/src/session/browser.py
@@ -21,29 +21,39 @@ class SessionBrowserItem:
     bad_rep_count: Optional[int]
 
 
-def list_recent_sessions(sessions_dir: Path, limit: int = 30) -> list[SessionBrowserItem]:
+@dataclass(frozen=True)
+class AnalyticsSnapshot:
+    """Minimal aggregate view for the analytics dashboard."""
+
+    total_sessions: int = 0
+    latest_timestamp: Optional[str] = None
+    latest_rep_count: Optional[int] = None
+    latest_bad_rep_count: Optional[int] = None
+    latest_bad_rep_percentage: Optional[float] = None
+    previous_rep_count: Optional[int] = None
+    rep_count_change: Optional[int] = None
+    bad_rep_count_change: Optional[int] = None
+
+
+def list_recent_sessions(
+    sessions_dir: Path, limit: Optional[int] = 30
+) -> list[SessionBrowserItem]:
     """Return saved sessions sorted newest-first by timestamp folder name."""
     if not sessions_dir.exists():
         return []
 
     folders = [path for path in sessions_dir.iterdir() if path.is_dir()]
     folders.sort(key=lambda path: path.name, reverse=True)
+    if limit is not None:
+        folders = folders[:limit]
 
     items: list[SessionBrowserItem] = []
-    for folder in folders[:limit]:
+    for folder in folders:
         summary_path = folder / "summary.json"
         video_path = folder / "session.mp4"
-        rep_count = None
-        bad_rep_count = None
-
-        if summary_path.exists():
-            try:
-                with summary_path.open("r", encoding="utf-8") as file:
-                    data = json.load(file)
-                rep_count = _safe_int(data.get("rep_count"))
-                bad_rep_count = _safe_int(data.get("bad_rep_count"))
-            except (json.JSONDecodeError, OSError):
-                pass
+        data = _load_summary_data(summary_path)
+        rep_count = _safe_int(data.get("rep_count")) if data else None
+        bad_rep_count = _safe_int(data.get("bad_rep_count")) if data else None
 
         items.append(
             SessionBrowserItem(
@@ -57,6 +67,44 @@ def list_recent_sessions(sessions_dir: Path, limit: int = 30) -> list[SessionBro
         )
 
     return items
+
+
+def load_analytics_snapshot(sessions_dir: Path) -> AnalyticsSnapshot:
+    """Load lightweight aggregate analytics from saved session summaries."""
+    sessions = list_recent_sessions(sessions_dir, limit=None)
+    if not sessions:
+        return AnalyticsSnapshot()
+
+    latest = sessions[0]
+    previous = sessions[1] if len(sessions) > 1 else None
+
+    latest_rep_count = latest.rep_count
+    latest_bad_rep_count = latest.bad_rep_count
+    latest_bad_rep_percentage = None
+    if latest_rep_count is not None and latest_bad_rep_count is not None:
+        if latest_rep_count > 0:
+            latest_bad_rep_percentage = (latest_bad_rep_count / latest_rep_count) * 100.0
+        else:
+            latest_bad_rep_percentage = 0.0
+
+    previous_rep_count = previous.rep_count if previous else None
+    rep_count_change = None
+    bad_rep_count_change = None
+    if previous and latest_rep_count is not None and previous.rep_count is not None:
+        rep_count_change = latest_rep_count - previous.rep_count
+    if previous and latest_bad_rep_count is not None and previous.bad_rep_count is not None:
+        bad_rep_count_change = latest_bad_rep_count - previous.bad_rep_count
+
+    return AnalyticsSnapshot(
+        total_sessions=len(sessions),
+        latest_timestamp=latest.folder_name,
+        latest_rep_count=latest_rep_count,
+        latest_bad_rep_count=latest_bad_rep_count,
+        latest_bad_rep_percentage=latest_bad_rep_percentage,
+        previous_rep_count=previous_rep_count,
+        rep_count_change=rep_count_change,
+        bad_rep_count_change=bad_rep_count_change,
+    )
 
 
 def open_session_video(session: SessionBrowserItem) -> None:
@@ -75,6 +123,17 @@ def open_session_folder(session: SessionBrowserItem) -> None:
         return
 
     os.startfile(str(session.folder_path))
+
+
+def _load_summary_data(summary_path: Path) -> Optional[dict]:
+    if not summary_path.exists():
+        return None
+
+    try:
+        with summary_path.open("r", encoding="utf-8") as file:
+            return json.load(file)
+    except (json.JSONDecodeError, OSError):
+        return None
 
 
 def _safe_int(value) -> Optional[int]:

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 import json
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -22,9 +22,18 @@ class SessionSummary:
     rep_count: int = 0
     bad_rep_count: int = 0
     events: List[RepEvent] = field(default_factory=list)
+    knee_angles: List[float] = field(default_factory=list)
+    issue_counts: Dict[str, int] = field(default_factory=dict)
 
     def add_event(self, timestamp: float, label: str, reason: str = "") -> None:
         self.events.append(RepEvent(timestamp=timestamp, label=label, reason=reason))
+
+    def add_knee_angle(self, angle: float) -> None:
+        self.knee_angles.append(angle)
+
+    def record_issue(self, reason: str) -> None:
+        for issue in self._split_issues(reason):
+            self.issue_counts[issue] = self.issue_counts.get(issue, 0) + 1
 
     def record_rep_start(self, timestamp: float) -> None:
         self.add_event(timestamp=timestamp, label="rep_start")
@@ -37,6 +46,10 @@ class SessionSummary:
             "started_at": self.started_at.isoformat(),
             "rep_count": self.rep_count,
             "bad_rep_count": self.bad_rep_count,
+            "avg_knee_angle": self._average_knee_angle(),
+            "min_knee_angle": self._minimum_knee_angle(),
+            "issue_counts": dict(sorted(self.issue_counts.items())),
+            "most_common_issue": self._most_common_issue(),
             "events": [
                 {
                     "timestamp": event.timestamp,
@@ -53,3 +66,26 @@ class SessionSummary:
         with output_path.open("w", encoding="utf-8") as file:
             json.dump(self.to_dict(), file, indent=2)
         return output_path
+
+    def _average_knee_angle(self) -> Optional[float]:
+        if not self.knee_angles:
+            return None
+        return round(sum(self.knee_angles) / len(self.knee_angles), 2)
+
+    def _minimum_knee_angle(self) -> Optional[float]:
+        if not self.knee_angles:
+            return None
+        return round(min(self.knee_angles), 2)
+
+    def _most_common_issue(self) -> Optional[str]:
+        if not self.issue_counts:
+            return None
+        sorted_issues = sorted(
+            self.issue_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+        return sorted_issues[0][0]
+
+    @staticmethod
+    def _split_issues(reason: str) -> List[str]:
+        return [issue.strip() for issue in reason.split(",") if issue.strip()]

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -43,7 +43,7 @@ class OverlayRenderer:
         self._fill_background(frame_bgr)
         frame_h, frame_w = frame_bgr.shape[:2]
         panel_w = min(780, frame_w - 140)
-        panel_h = 390
+        panel_h = 450
         panel_x = (frame_w - panel_w) // 2
         panel_y = max(70, (frame_h - panel_h) // 2)
 
@@ -68,7 +68,7 @@ class OverlayRenderer:
         )
         self._put_text(
             frame_bgr,
-            "AI-based real-time posture correction for home workouts",
+            "Real-time posture correction for home workouts",
             panel_x + 50,
             panel_y + 126,
             scale=0.66,
@@ -80,6 +80,7 @@ class OverlayRenderer:
         options = [
             ("S", "Start squat session"),
             ("B", "Browse saved sessions"),
+            ("A", "Open analytics dashboard"),
             ("Q", "Quit application"),
         ]
         row_y = panel_y + 190
@@ -96,7 +97,7 @@ class OverlayRenderer:
 
         self._put_text(
             frame_bgr,
-            "Press the highlighted key to continue. Use D during a session for debug metrics.",
+            "Press the highlighted key to continue. Use D for debug metrics during a session.",
             panel_x + 50,
             panel_y + panel_h - 30,
             scale=0.48,
@@ -258,6 +259,206 @@ class OverlayRenderer:
             )
             row_y += 46
 
+    def draw_analytics(self, frame_bgr, snapshot) -> None:
+        self._fill_background(frame_bgr)
+        frame_h, frame_w = frame_bgr.shape[:2]
+        margin = 36
+
+        self._put_text(
+            frame_bgr,
+            "Analytics Dashboard",
+            margin,
+            58,
+            scale=1.18,
+            color=self.PRIMARY,
+            thickness=2,
+        )
+        self._put_text(
+            frame_bgr,
+            "R: refresh    Backspace / Esc: dashboard",
+            margin + 2,
+            96,
+            scale=0.58,
+            color=self.MUTED,
+            thickness=1,
+            max_width=frame_w - (margin * 2),
+        )
+
+        summary_x = margin
+        summary_y = 132
+        summary_w = frame_w - (margin * 2)
+        summary_h = 250
+        self._draw_panel(
+            frame_bgr,
+            summary_x,
+            summary_y,
+            summary_w,
+            summary_h,
+            border_color=self.BORDER,
+            alpha=0.9,
+        )
+
+        self._put_text(
+            frame_bgr,
+            "Session Summary",
+            summary_x + 28,
+            summary_y + 42,
+            scale=0.72,
+            color=self.TEXT,
+            thickness=1,
+        )
+
+        if snapshot.total_sessions == 0:
+            self._put_text(
+                frame_bgr,
+                "No data available yet.",
+                summary_x + 28,
+                summary_y + 104,
+                scale=0.86,
+                color=self.TEXT,
+                thickness=1,
+                max_width=summary_w - 56,
+            )
+            self._put_text(
+                frame_bgr,
+                "Complete and save a workout session to populate analytics.",
+                summary_x + 28,
+                summary_y + 146,
+                scale=0.58,
+                color=self.MUTED,
+                thickness=1,
+                max_width=summary_w - 56,
+            )
+            return
+
+        timestamp_text = self._format_session_timestamp(snapshot.latest_timestamp)
+        self._put_text(
+            frame_bgr,
+            f"Latest session: {timestamp_text}",
+            summary_x + 28,
+            summary_y + 84,
+            scale=0.62,
+            color=self.MUTED,
+            thickness=1,
+            max_width=summary_w - 56,
+        )
+
+        cards_y = summary_y + 122
+        cards_x = summary_x + 24
+        cards_gap = 16
+        cards_w = summary_w - 48
+        card_w = (cards_w - (cards_gap * 3)) // 4
+        card_h = 96
+
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x,
+            cards_y,
+            card_w,
+            card_h,
+            "Total Sessions",
+            str(snapshot.total_sessions),
+            self.PRIMARY,
+        )
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x + (card_w + cards_gap),
+            cards_y,
+            card_w,
+            card_h,
+            "Latest Reps",
+            self._format_metric_value(snapshot.latest_rep_count),
+            self.TEXT,
+        )
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x + ((card_w + cards_gap) * 2),
+            cards_y,
+            card_w,
+            card_h,
+            "Latest Bad Reps",
+            self._format_metric_value(snapshot.latest_bad_rep_count),
+            self.ERROR if (snapshot.latest_bad_rep_count or 0) > 0 else self.TEXT,
+        )
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x + ((card_w + cards_gap) * 3),
+            cards_y,
+            card_w,
+            card_h,
+            "Bad Rep Rate",
+            self._format_percentage(snapshot.latest_bad_rep_percentage),
+            self.WARNING if (snapshot.latest_bad_rep_percentage or 0.0) > 0 else self.TEXT,
+        )
+
+        progress_x = margin
+        progress_y = summary_y + summary_h + 24
+        progress_w = frame_w - (margin * 2)
+        progress_h = frame_h - progress_y - margin
+        self._draw_panel(
+            frame_bgr,
+            progress_x,
+            progress_y,
+            progress_w,
+            progress_h,
+            border_color=self.BORDER,
+            alpha=0.9,
+        )
+        self._put_text(
+            frame_bgr,
+            "Progress vs Previous Session",
+            progress_x + 28,
+            progress_y + 42,
+            scale=0.72,
+            color=self.TEXT,
+            thickness=1,
+        )
+
+        previous_text = self._format_metric_value(snapshot.previous_rep_count)
+        self._put_text(
+            frame_bgr,
+            f"Previous rep count: {previous_text}",
+            progress_x + 28,
+            progress_y + 82,
+            scale=0.6,
+            color=self.MUTED,
+            thickness=1,
+            max_width=progress_w - 56,
+        )
+
+        delta_cards_y = progress_y + 112
+        delta_card_w = (progress_w - 72) // 2
+        delta_card_h = 90
+
+        rep_delta_text = self._format_change(snapshot.rep_count_change)
+        rep_delta_color = self._change_color(snapshot.rep_count_change, positive_is_good=True)
+        self._draw_metric_tile(
+            frame_bgr,
+            progress_x + 24,
+            delta_cards_y,
+            delta_card_w,
+            delta_card_h,
+            "Rep Count Change",
+            rep_delta_text,
+            rep_delta_color,
+        )
+
+        bad_delta_text = self._format_change(snapshot.bad_rep_count_change)
+        bad_delta_color = self._change_color(
+            snapshot.bad_rep_count_change,
+            positive_is_good=False,
+        )
+        self._draw_metric_tile(
+            frame_bgr,
+            progress_x + 40 + delta_card_w,
+            delta_cards_y,
+            delta_card_w,
+            delta_card_h,
+            "Bad Rep Change",
+            bad_delta_text,
+            bad_delta_color,
+        )
+
     def draw_debug(self, frame_bgr, debug_info: dict) -> None:
         lines = [
             "Debug (D to toggle)",
@@ -405,6 +606,48 @@ class OverlayRenderer:
             max_width=panel_w - (pad * 2),
         )
 
+    def _draw_metric_tile(
+        self,
+        frame_bgr,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        label: str,
+        value: str,
+        value_color: tuple[int, int, int],
+    ) -> None:
+        self._draw_panel(
+            frame_bgr,
+            x,
+            y,
+            width,
+            height,
+            color=self.PANEL_ALT,
+            border_color=self.BORDER,
+            alpha=0.94,
+        )
+        self._put_text(
+            frame_bgr,
+            label,
+            x + 16,
+            y + 28,
+            scale=0.5,
+            color=self.MUTED,
+            thickness=1,
+            max_width=width - 32,
+        )
+        self._put_text(
+            frame_bgr,
+            value,
+            x + 16,
+            y + 66,
+            scale=0.88,
+            color=value_color,
+            thickness=1,
+            max_width=width - 32,
+        )
+
     def _draw_feedback(
         self, frame_bgr, message: str, feedback_level: str = "info"
     ) -> None:
@@ -546,9 +789,7 @@ class OverlayRenderer:
             cv2.LINE_AA,
         )
 
-    def _fit_text(
-        self, text: str, max_width: int, scale: float, thickness: int
-    ) -> str:
+    def _fit_text(self, text: str, max_width: int, scale: float, thickness: int) -> str:
         if max_width <= 0:
             return "..."
         if self._text_width(text, scale, thickness) <= max_width:
@@ -574,4 +815,44 @@ class OverlayRenderer:
     def _format_result(value: str) -> str:
         if not value or value == "none":
             return "none"
+        return value
+
+    @staticmethod
+    def _format_metric_value(value) -> str:
+        if value is None:
+            return "N/A"
+        return str(value)
+
+    @staticmethod
+    def _format_percentage(value: float | None) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.1f}%"
+
+    @staticmethod
+    def _format_change(value: int | None) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:+d}"
+
+    def _change_color(
+        self, value: int | None, *, positive_is_good: bool
+    ) -> tuple[int, int, int]:
+        if value is None or value == 0:
+            return self.TEXT
+        if positive_is_good:
+            return self.PRIMARY if value > 0 else self.WARNING
+        return self.PRIMARY if value < 0 else self.ERROR
+
+    @staticmethod
+    def _format_session_timestamp(value: str | None) -> str:
+        if not value:
+            return "N/A"
+        if len(value) == 15 and "_" in value:
+            date_part, time_part = value.split("_", maxsplit=1)
+            if len(date_part) == 8 and len(time_part) == 6:
+                return (
+                    f"{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
+                    f"{time_part[0:2]}:{time_part[2:4]}:{time_part[4:6]}"
+                )
         return value

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -81,7 +81,7 @@ class OverlayRenderer:
             ("S", "Start squat session"),
             ("B", "Browse saved sessions"),
             ("A", "Open analytics dashboard"),
-            ("Q", "Quit application"),
+            ("Esc", "Quit application"),
         ]
         row_y = panel_y + 190
         for key, label in options:
@@ -97,7 +97,7 @@ class OverlayRenderer:
 
         self._put_text(
             frame_bgr,
-            "Press the highlighted key to continue. Use D for debug metrics during a session.",
+            "Press the highlighted key to continue. Use Esc to close or go back from menus.",
             panel_x + 50,
             panel_y + panel_h - 30,
             scale=0.48,
@@ -122,7 +122,7 @@ class OverlayRenderer:
         )
         self._put_text(
             frame_bgr,
-            "Up/Down: select    P: play video    O: open folder    Backspace: dashboard",
+            "Up/Down: select    P: play video    O: open folder    Esc: dashboard",
             margin + 2,
             96,
             scale=0.58,
@@ -263,6 +263,7 @@ class OverlayRenderer:
         self._fill_background(frame_bgr)
         frame_h, frame_w = frame_bgr.shape[:2]
         margin = 36
+        compact_layout = frame_h < 900
 
         self._put_text(
             frame_bgr,
@@ -275,7 +276,7 @@ class OverlayRenderer:
         )
         self._put_text(
             frame_bgr,
-            "R: refresh    Backspace / Esc: dashboard",
+            "R: refresh    Esc: dashboard",
             margin + 2,
             96,
             scale=0.58,
@@ -287,7 +288,12 @@ class OverlayRenderer:
         summary_x = margin
         summary_y = 132
         summary_w = frame_w - (margin * 2)
-        summary_h = 250
+        progress_gap = 20
+        min_progress_h = 194 if compact_layout else 220
+        desired_summary_h = 338 if compact_layout else 392
+        available_h = frame_h - summary_y - margin
+        summary_h = min(desired_summary_h, available_h - progress_gap - min_progress_h)
+        summary_h = max(258 if compact_layout else 320, summary_h)
         self._draw_panel(
             frame_bgr,
             summary_x,
@@ -300,7 +306,7 @@ class OverlayRenderer:
 
         self._put_text(
             frame_bgr,
-            "Session Summary",
+            "Latest Meaningful Session",
             summary_x + 28,
             summary_y + 42,
             scale=0.72,
@@ -308,62 +314,84 @@ class OverlayRenderer:
             thickness=1,
         )
 
-        if snapshot.total_sessions == 0:
+        has_meaningful_data = snapshot.meaningful_session_count > 0
+        if not has_meaningful_data:
             self._put_text(
                 frame_bgr,
-                "No data available yet.",
+                "No meaningful session data available.",
                 summary_x + 28,
-                summary_y + 104,
-                scale=0.86,
+                summary_y + 90,
+                scale=0.72,
                 color=self.TEXT,
                 thickness=1,
                 max_width=summary_w - 56,
             )
             self._put_text(
                 frame_bgr,
-                "Complete and save a workout session to populate analytics.",
+                (
+                    "Saved session folders exist, but none contain completed workout data yet."
+                    if snapshot.total_sessions > 0
+                    else "Complete and save a workout session to populate analytics."
+                ),
                 summary_x + 28,
-                summary_y + 146,
-                scale=0.58,
+                summary_y + 118,
+                scale=0.54,
                 color=self.MUTED,
                 thickness=1,
                 max_width=summary_w - 56,
             )
-            return
+        else:
+            timestamp_text = self._format_session_timestamp(snapshot.latest_timestamp)
+            self._put_text(
+                frame_bgr,
+                f"Latest session: {timestamp_text}",
+                summary_x + 28,
+                summary_y + 84,
+                scale=0.62,
+                color=self.MUTED,
+                thickness=1,
+                max_width=summary_w - 56,
+            )
 
-        timestamp_text = self._format_session_timestamp(snapshot.latest_timestamp)
-        self._put_text(
-            frame_bgr,
-            f"Latest session: {timestamp_text}",
-            summary_x + 28,
-            summary_y + 84,
-            scale=0.62,
-            color=self.MUTED,
-            thickness=1,
-            max_width=summary_w - 56,
+        summary_cards_y = summary_y + (
+            148 if not has_meaningful_data and compact_layout else
+            160 if not has_meaningful_data else
+            116 if compact_layout else
+            122
         )
-
-        cards_y = summary_y + 122
         cards_x = summary_x + 24
         cards_gap = 16
         cards_w = summary_w - 48
-        card_w = (cards_w - (cards_gap * 3)) // 4
-        card_h = 96
+        card_w = (cards_w - (cards_gap * 2)) // 3
+        card_h = 60 if not has_meaningful_data else 72 if compact_layout else 84
+        row_gap = 10 if compact_layout else 12
+        issue_h = 44 if compact_layout else 52
 
         self._draw_metric_tile(
             frame_bgr,
             cards_x,
-            cards_y,
+            summary_cards_y,
             card_w,
             card_h,
             "Total Sessions",
             str(snapshot.total_sessions),
             self.PRIMARY,
         )
+        self._put_text(
+            frame_bgr,
+            f"Meaningful sessions: {snapshot.meaningful_session_count}",
+            summary_x + 28,
+            summary_y + (136 if not has_meaningful_data else 104 if compact_layout else 110),
+            scale=0.58,
+            color=self.MUTED,
+            thickness=1,
+            max_width=summary_w - 56,
+        )
+
         self._draw_metric_tile(
             frame_bgr,
-            cards_x + (card_w + cards_gap),
-            cards_y,
+            cards_x + card_w + cards_gap,
+            summary_cards_y,
             card_w,
             card_h,
             "Latest Reps",
@@ -373,26 +401,63 @@ class OverlayRenderer:
         self._draw_metric_tile(
             frame_bgr,
             cards_x + ((card_w + cards_gap) * 2),
-            cards_y,
+            summary_cards_y,
             card_w,
             card_h,
             "Latest Bad Reps",
             self._format_metric_value(snapshot.latest_bad_rep_count),
             self.ERROR if (snapshot.latest_bad_rep_count or 0) > 0 else self.TEXT,
         )
+
+        second_row_y = summary_cards_y + card_h + row_gap
         self._draw_metric_tile(
             frame_bgr,
-            cards_x + ((card_w + cards_gap) * 3),
-            cards_y,
+            cards_x,
+            second_row_y,
             card_w,
             card_h,
             "Bad Rep Rate",
             self._format_percentage(snapshot.latest_bad_rep_percentage),
             self.WARNING if (snapshot.latest_bad_rep_percentage or 0.0) > 0 else self.TEXT,
         )
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x + card_w + cards_gap,
+            second_row_y,
+            card_w,
+            card_h,
+            "Avg Knee Angle",
+            self._format_angle(snapshot.latest_avg_knee_angle),
+            self.TEXT,
+        )
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x + ((card_w + cards_gap) * 2),
+            second_row_y,
+            card_w,
+            card_h,
+            "Min Knee Angle",
+            self._format_angle(snapshot.latest_min_knee_angle),
+            self.TEXT,
+        )
+
+        issue_text = self._format_issue(snapshot.latest_most_common_issue)
+        issue_y = second_row_y + card_h + row_gap
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x,
+            issue_y,
+            cards_w,
+            issue_h,
+            "Most Common Issue",
+            issue_text,
+            self.TEXT,
+            label_scale=0.46,
+            value_scale=0.54 if compact_layout else 0.6,
+        )
 
         progress_x = margin
-        progress_y = summary_y + summary_h + 24
+        progress_y = summary_y + summary_h + progress_gap
         progress_w = frame_w - (margin * 2)
         progress_h = frame_h - progress_y - margin
         self._draw_panel(
@@ -406,12 +471,24 @@ class OverlayRenderer:
         )
         self._put_text(
             frame_bgr,
-            "Progress vs Previous Session",
+            "Progress vs Previous Meaningful Session",
             progress_x + 28,
-            progress_y + 42,
+            progress_y + (38 if compact_layout else 42),
             scale=0.72,
             color=self.TEXT,
             thickness=1,
+        )
+
+        previous_timestamp_text = self._format_session_timestamp(snapshot.previous_timestamp)
+        self._put_text(
+            frame_bgr,
+            f"Previous meaningful session: {previous_timestamp_text}",
+            progress_x + 28,
+            progress_y + (68 if compact_layout else 74),
+            scale=0.58,
+            color=self.MUTED,
+            thickness=1,
+            max_width=progress_w - 56,
         )
 
         previous_text = self._format_metric_value(snapshot.previous_rep_count)
@@ -419,16 +496,16 @@ class OverlayRenderer:
             frame_bgr,
             f"Previous rep count: {previous_text}",
             progress_x + 28,
-            progress_y + 82,
+            progress_y + (92 if compact_layout else 100),
             scale=0.6,
             color=self.MUTED,
             thickness=1,
             max_width=progress_w - 56,
         )
 
-        delta_cards_y = progress_y + 112
+        delta_cards_y = progress_y + (110 if compact_layout else 124)
         delta_card_w = (progress_w - 72) // 2
-        delta_card_h = 90
+        delta_card_h = 60 if compact_layout else 72
 
         rep_delta_text = self._format_change(snapshot.rep_count_change)
         rep_delta_color = self._change_color(snapshot.rep_count_change, positive_is_good=True)
@@ -529,7 +606,7 @@ class OverlayRenderer:
         panel_x = 20
         panel_y = 20
         panel_w = 470
-        panel_h = 158
+        panel_h = 184
         pad = 18
 
         self._draw_panel(
@@ -605,6 +682,16 @@ class OverlayRenderer:
             thickness=1,
             max_width=panel_w - (pad * 2),
         )
+        self._put_text(
+            frame_bgr,
+            "Esc: end session    D: debug overlay",
+            panel_x + pad,
+            panel_y + 170,
+            scale=0.48,
+            color=self.MUTED,
+            thickness=1,
+            max_width=panel_w - (pad * 2),
+        )
 
     def _draw_metric_tile(
         self,
@@ -616,7 +703,15 @@ class OverlayRenderer:
         label: str,
         value: str,
         value_color: tuple[int, int, int],
+        label_scale: float = 0.5,
+        value_scale: float | None = None,
     ) -> None:
+        compact_tile = height < 72
+        label_y = y + (24 if compact_tile else 28)
+        value_y = y + height - (14 if compact_tile else 18)
+        if value_scale is None:
+            value_scale = 0.72 if compact_tile else 0.88
+
         self._draw_panel(
             frame_bgr,
             x,
@@ -631,8 +726,8 @@ class OverlayRenderer:
             frame_bgr,
             label,
             x + 16,
-            y + 28,
-            scale=0.5,
+            label_y,
+            scale=label_scale,
             color=self.MUTED,
             thickness=1,
             max_width=width - 32,
@@ -641,8 +736,8 @@ class OverlayRenderer:
             frame_bgr,
             value,
             x + 16,
-            y + 66,
-            scale=0.88,
+            value_y,
+            scale=value_scale,
             color=value_color,
             thickness=1,
             max_width=width - 32,
@@ -696,6 +791,12 @@ class OverlayRenderer:
         self, frame_bgr, x: int, y: int, width: int, key: str, label: str
     ) -> None:
         row_h = 48
+        key_scale = 0.62
+        key_thickness = 1
+        key_width = self._text_width(key, key_scale, key_thickness)
+        key_box_w = max(36, key_width + 20)
+        key_box_x = x + 18
+
         self._draw_panel(
             frame_bgr,
             x,
@@ -706,27 +807,39 @@ class OverlayRenderer:
             border_color=self.BORDER,
             alpha=0.94,
         )
-        cv2.rectangle(frame_bgr, (x + 18, y - 24), (x + 54, y + 10), self.BG_SOFT, -1)
-        cv2.rectangle(frame_bgr, (x + 18, y - 24), (x + 54, y + 10), self.PRIMARY, 1)
+        cv2.rectangle(
+            frame_bgr,
+            (key_box_x, y - 24),
+            (key_box_x + key_box_w, y + 10),
+            self.BG_SOFT,
+            -1,
+        )
+        cv2.rectangle(
+            frame_bgr,
+            (key_box_x, y - 24),
+            (key_box_x + key_box_w, y + 10),
+            self.PRIMARY,
+            1,
+        )
         self._put_text(
             frame_bgr,
             key,
-            x + 29,
+            key_box_x + ((key_box_w - key_width) // 2),
             y,
-            scale=0.66,
+            scale=key_scale,
             color=self.PRIMARY,
-            thickness=1,
-            max_width=24,
+            thickness=key_thickness,
+            max_width=key_box_w - 12,
         )
         self._put_text(
             frame_bgr,
             label,
-            x + 76,
+            key_box_x + key_box_w + 22,
             y,
             scale=0.68,
             color=self.TEXT,
             thickness=1,
-            max_width=width - 96,
+            max_width=width - key_box_w - 58,
         )
 
     def _fill_background(self, frame_bgr) -> None:
@@ -834,6 +947,18 @@ class OverlayRenderer:
         if value is None:
             return "N/A"
         return f"{value:+d}"
+
+    @staticmethod
+    def _format_angle(value: float | None) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.1f} deg"
+
+    @staticmethod
+    def _format_issue(value: str | None) -> str:
+        if not value:
+            return "none"
+        return value.replace("_", " ")
 
     def _change_color(
         self, value: int | None, *, positive_is_good: bool


### PR DESCRIPTION
Closes Issue #32 

- Added an analytical dashboard view to present session-level insights
- Loaded metrics from saved session summaries
- Displayed latest-session and comparison data using the existing OpenCV UI flow