### PR TITLE
feat: add joint-angle insights to session analytics

### DIFF
--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -13,10 +13,12 @@ from core.config import SQUAT_CONFIG
 class SquatState:
     label: str
     knee_angle: Optional[float]
+    ankle_angle: Optional[float] = None
+    torso_angle: Optional[float] = None
 
 
 class SquatStateAnalyzer:
-    """Classify a squat as standing, down, or transition using knee angles."""
+    """Classify a squat and expose simple joint-angle analytics."""
 
     def classify(self, pose_result) -> SquatState:
         # pose_result.pose_landmarks -> list of poses; each pose -> list of landmarks
@@ -31,41 +33,85 @@ class SquatStateAnalyzer:
         # Key indices we need (BlazePose):
         # 23 left hip, 25 left knee, 27 left ankle
         # 24 right hip, 26 right knee, 28 right ankle
-        left = self._knee_angle_if_visible(landmarks, 23, 25, 27)
-        right = self._knee_angle_if_visible(landmarks, 24, 26, 28)
+        knee_angle = self._average_angle(
+            [
+                self._angle_if_visible(landmarks, 23, 25, 27),
+                self._angle_if_visible(landmarks, 24, 26, 28),
+            ]
+        )
+        ankle_angle = self._average_angle(
+            [
+                self._angle_if_visible(landmarks, 25, 27, 31),
+                self._angle_if_visible(landmarks, 26, 28, 32),
+            ]
+        )
+        torso_angle = self._average_angle(
+            [
+                self._torso_angle_if_visible(landmarks, 11, 23),
+                self._torso_angle_if_visible(landmarks, 12, 24),
+            ]
+        )
 
-        angle = self._average_angle([left, right])
-        if angle is None:
-            return SquatState(label="no_pose", knee_angle=None)
+        if knee_angle is None:
+            return SquatState(
+                label="no_pose",
+                knee_angle=None,
+                ankle_angle=ankle_angle,
+                torso_angle=torso_angle,
+            )
 
-        if angle <= SQUAT_CONFIG.down_knee_angle:
-            return SquatState(label="down", knee_angle=angle)
-        if angle >= SQUAT_CONFIG.up_knee_angle:
-            return SquatState(label="standing", knee_angle=angle)
+        if knee_angle <= SQUAT_CONFIG.down_knee_angle:
+            label = "down"
+        elif knee_angle >= SQUAT_CONFIG.up_knee_angle:
+            label = "standing"
+        else:
+            label = "transition"
 
-        return SquatState(label="transition", knee_angle=angle)
+        return SquatState(
+            label=label,
+            knee_angle=knee_angle,
+            ankle_angle=ankle_angle,
+            torso_angle=torso_angle,
+        )
 
-    def _knee_angle_if_visible(
-        self, landmarks, hip_i, knee_i, ankle_i
+    def _angle_if_visible(
+        self, landmarks, point_a: int, point_b: int, point_c: int
     ) -> Optional[float]:
-        hip = landmarks[hip_i]
-        knee = landmarks[knee_i]
-        ankle = landmarks[ankle_i]
-
-        # Tasks landmarks may include visibility/presence depending on model; be defensive.
-        vis = [
-            getattr(hip, "visibility", 1.0),
-            getattr(knee, "visibility", 1.0),
-            getattr(ankle, "visibility", 1.0),
-        ]
-        if min(vis) < 0.5:
+        if not self._landmarks_visible(landmarks, point_a, point_b, point_c):
             return None
 
+        landmark_a = landmarks[point_a]
+        landmark_b = landmarks[point_b]
+        landmark_c = landmarks[point_c]
         return _angle_degrees(
-            (hip.x, hip.y),
-            (knee.x, knee.y),
-            (ankle.x, ankle.y),
+            (landmark_a.x, landmark_a.y),
+            (landmark_b.x, landmark_b.y),
+            (landmark_c.x, landmark_c.y),
         )
+
+    def _torso_angle_if_visible(
+        self, landmarks, shoulder_i: int, hip_i: int
+    ) -> Optional[float]:
+        if not self._landmarks_visible(landmarks, shoulder_i, hip_i):
+            return None
+
+        shoulder = landmarks[shoulder_i]
+        hip = landmarks[hip_i]
+        dx = shoulder.x - hip.x
+        dy = shoulder.y - hip.y
+        if dx == 0 and dy == 0:
+            return 0.0
+
+        vertical_span = abs(dy)
+        if vertical_span == 0:
+            return 90.0
+
+        return math.degrees(math.atan2(abs(dx), vertical_span))
+
+    @staticmethod
+    def _landmarks_visible(landmarks, *indices: int) -> bool:
+        visibilities = [getattr(landmarks[index], "visibility", 1.0) for index in indices]
+        return min(visibilities) >= 0.5
 
     @staticmethod
     def _average_angle(values: Iterable[Optional[float]]) -> Optional[float]:

--- a/src/app.py
+++ b/src/app.py
@@ -208,8 +208,11 @@ def run_session(overlay: OverlayRenderer) -> None:
             squat_state = analyzer.classify(results)
             rep_update = rep_counter.update(squat_state, timestamp)
 
-            if squat_state.knee_angle is not None:
-                summary.add_knee_angle(squat_state.knee_angle)
+            summary.add_pose_metrics(
+                knee_angle=squat_state.knee_angle,
+                ankle_angle=squat_state.ankle_angle,
+                torso_angle=squat_state.torso_angle,
+            )
 
             elapsed = timestamp - start_time
             if rep_update.rep_started:

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -23,6 +23,8 @@ class SessionSummary:
     bad_rep_count: int = 0
     events: List[RepEvent] = field(default_factory=list)
     knee_angles: List[float] = field(default_factory=list)
+    ankle_angles: List[float] = field(default_factory=list)
+    torso_angles: List[float] = field(default_factory=list)
     issue_counts: Dict[str, int] = field(default_factory=dict)
 
     def add_event(self, timestamp: float, label: str, reason: str = "") -> None:
@@ -30,6 +32,20 @@ class SessionSummary:
 
     def add_knee_angle(self, angle: float) -> None:
         self.knee_angles.append(angle)
+
+    def add_pose_metrics(
+        self,
+        *,
+        knee_angle: Optional[float] = None,
+        ankle_angle: Optional[float] = None,
+        torso_angle: Optional[float] = None,
+    ) -> None:
+        if knee_angle is not None:
+            self.knee_angles.append(knee_angle)
+        if ankle_angle is not None:
+            self.ankle_angles.append(ankle_angle)
+        if torso_angle is not None:
+            self.torso_angles.append(torso_angle)
 
     def record_issue(self, reason: str) -> None:
         for issue in self._split_issues(reason):
@@ -48,6 +64,9 @@ class SessionSummary:
             "bad_rep_count": self.bad_rep_count,
             "avg_knee_angle": self._average_knee_angle(),
             "min_knee_angle": self._minimum_knee_angle(),
+            "avg_ankle_angle": self._average_ankle_angle(),
+            "min_ankle_angle": self._minimum_ankle_angle(),
+            "avg_torso_angle": self._average_torso_angle(),
             "issue_counts": dict(sorted(self.issue_counts.items())),
             "most_common_issue": self._most_common_issue(),
             "events": [
@@ -68,14 +87,19 @@ class SessionSummary:
         return output_path
 
     def _average_knee_angle(self) -> Optional[float]:
-        if not self.knee_angles:
-            return None
-        return round(sum(self.knee_angles) / len(self.knee_angles), 2)
+        return self._average_value(self.knee_angles)
 
     def _minimum_knee_angle(self) -> Optional[float]:
-        if not self.knee_angles:
-            return None
-        return round(min(self.knee_angles), 2)
+        return self._minimum_value(self.knee_angles)
+
+    def _average_ankle_angle(self) -> Optional[float]:
+        return self._average_value(self.ankle_angles)
+
+    def _minimum_ankle_angle(self) -> Optional[float]:
+        return self._minimum_value(self.ankle_angles)
+
+    def _average_torso_angle(self) -> Optional[float]:
+        return self._average_value(self.torso_angles)
 
     def _most_common_issue(self) -> Optional[str]:
         if not self.issue_counts:
@@ -89,3 +113,15 @@ class SessionSummary:
     @staticmethod
     def _split_issues(reason: str) -> List[str]:
         return [issue.strip() for issue in reason.split(",") if issue.strip()]
+
+    @staticmethod
+    def _average_value(values: List[float]) -> Optional[float]:
+        if not values:
+            return None
+        return round(sum(values) / len(values), 2)
+
+    @staticmethod
+    def _minimum_value(values: List[float]) -> Optional[float]:
+        if not values:
+            return None
+        return round(min(values), 2)


### PR DESCRIPTION
Closes Issue #34 

What changed:
- Added additional joint-angle analytics beyond knee angle
- Persisted ankle and torso/posture metrics in session summaries
- Preserved existing rep counting, shallow squat detection, recording, and browser flow

How to run/test:
python src/app.py

Test steps:
- Run a squat session
- End the session
- Open the generated summary.json
- Confirm knee, ankle, and torso/posture metrics are present where available
- Confirm existing rep and bad rep counts still work

Evidence:
- summary.json now includes richer movement-quality analytics