### PR TITLE
fix: handle invalid sessions in analytics

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-"""GymGuardian MVP app entrypoint."""
+"""GymGuardian squat coach application entrypoint."""
 
 from __future__ import annotations
 
@@ -153,6 +153,18 @@ def _current_feedback(
     return None, "info"
 
 
+def _rep_feedback(issues: tuple[str, ...], is_bad: bool) -> tuple[str, str]:
+    if is_bad and "too_shallow" in issues:
+        return "Bad rep: increase squat depth", "bad"
+    if "torso_lean" in issues and "ankle_control" in issues:
+        return "Rep logged: improve torso and ankle control", "warning"
+    if "torso_lean" in issues:
+        return "Rep logged: reduce forward torso lean", "warning"
+    if "ankle_control" in issues:
+        return "Rep logged: improve ankle control", "warning"
+    return "Rep accepted", "ok"
+
+
 def run_session(overlay: OverlayRenderer) -> None:
     """Run one workout session and persist outputs on exit."""
     cap = cv2.VideoCapture(0)
@@ -203,6 +215,7 @@ def run_session(overlay: OverlayRenderer) -> None:
                         else (0.9 * fps_estimate + 0.1 * instant_fps)
                     )
             previous_frame_time = timestamp
+            summary.add_fps_sample(fps_estimate)
 
             results = detector.process(frame)
             squat_state = analyzer.classify(results)
@@ -219,14 +232,20 @@ def run_session(overlay: OverlayRenderer) -> None:
                 summary.record_rep_start(elapsed)
             if rep_update.rep_completed:
                 summary.record_rep_complete(elapsed, reason=rep_update.reason)
-                if rep_update.reason:
-                    summary.record_issue(rep_update.reason)
-                if rep_update.reason == "too_shallow":
-                    feedback_message = "Bad rep: too shallow"
-                    feedback_level = "bad"
-                else:
-                    feedback_message = "Rep accepted"
-                    feedback_level = "ok"
+                summary.record_completed_rep(
+                    rep_index=rep_counter.rep_count,
+                    timestamp=elapsed,
+                    is_bad=rep_update.is_bad,
+                    issues=rep_update.issues,
+                    min_knee_angle=rep_update.min_knee_angle,
+                    min_ankle_angle=rep_update.min_ankle_angle,
+                    max_torso_angle=rep_update.max_torso_angle,
+                )
+                summary.record_issues(rep_update.issues)
+                feedback_message, feedback_level = _rep_feedback(
+                    rep_update.issues,
+                    rep_update.is_bad,
+                )
                 feedback_until = timestamp + FEEDBACK_HOLD_SECONDS
 
             summary.rep_count = rep_counter.rep_count
@@ -257,11 +276,16 @@ def run_session(overlay: OverlayRenderer) -> None:
                     "fps": fps_estimate,
                     "pose_detected": pose_detected,
                     "knee_angle": squat_state.knee_angle,
+                    "ankle_angle": squat_state.ankle_angle,
+                    "torso_angle": squat_state.torso_angle,
                     "down_knee_angle": SQUAT_CONFIG.down_knee_angle,
                     "up_knee_angle": SQUAT_CONFIG.up_knee_angle,
                     "rep_bottom_knee_angle": SQUAT_CONFIG.rep_bottom_knee_angle,
                     "shallow_knee_angle": SQUAT_CONFIG.shallow_knee_angle,
+                    "ankle_control_angle": SQUAT_CONFIG.ankle_control_angle,
+                    "torso_lean_angle": SQUAT_CONFIG.torso_lean_angle,
                     "down_hold_frames": SQUAT_CONFIG.down_hold_frames,
+                    "ready_standing_frames": SQUAT_CONFIG.ready_standing_frames,
                     "min_rep_seconds": SQUAT_CONFIG.min_rep_seconds,
                 }
                 overlay.draw_debug(frame, debug_info)
@@ -283,6 +307,12 @@ def run_session(overlay: OverlayRenderer) -> None:
         cap.release()
 
         print(f"Session summary saved: {saved_path}")
+        rep_metrics_path = session_dir / "rep_metrics.csv"
+        if rep_metrics_path.exists():
+            print(f"Rep metrics exported: {rep_metrics_path}")
+        session_report_path = session_dir / "session_report.txt"
+        if session_report_path.exists():
+            print(f"Session report exported: {session_report_path}")
         if recorder_started and recorder.output_path.exists():
             print(f"Session video path: {recorder.output_path}")
 

--- a/src/session/browser.py
+++ b/src/session/browser.py
@@ -8,6 +8,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from session.insights import bad_rep_percentage, build_recommendation
+
 
 @dataclass(frozen=True)
 class SessionBrowserItem:
@@ -17,6 +19,7 @@ class SessionBrowserItem:
     folder_path: Path
     video_path: Path
     summary_path: Path
+    valid_session: bool
     rep_count: Optional[int]
     bad_rep_count: Optional[int]
 
@@ -51,6 +54,7 @@ class AnalyticsSessionItem:
     """Saved session data used by the analytics dashboard."""
 
     folder_name: str
+    valid_session: bool
     rep_count: int
     bad_rep_count: int
     avg_knee_angle: Optional[float]
@@ -79,13 +83,15 @@ def list_recent_sessions(
         data = _load_summary_data(summary_path)
         rep_count = _safe_int(data.get("rep_count")) if data else None
         bad_rep_count = _safe_int(data.get("bad_rep_count")) if data else None
+        valid_session = _derive_valid_session(data, rep_count)
 
         items.append(
             SessionBrowserItem(
-                folder_name=folder.name,
+                folder_name=_format_session_label(folder.name, valid_session),
                 folder_path=folder,
                 video_path=video_path,
                 summary_path=summary_path,
+                valid_session=valid_session,
                 rep_count=rep_count,
                 bad_rep_count=bad_rep_count,
             )
@@ -111,8 +117,12 @@ def load_analytics_snapshot(sessions_dir: Path) -> AnalyticsSnapshot:
     latest = meaningful_sessions[0]
     previous = meaningful_sessions[1] if len(meaningful_sessions) > 1 else None
 
-    latest_bad_rep_percentage = _bad_rep_percentage(latest)
-    previous_bad_rep_percentage = _bad_rep_percentage(previous) if previous else None
+    latest_bad_rep_percentage = bad_rep_percentage(latest.rep_count, latest.bad_rep_count)
+    previous_bad_rep_percentage = (
+        bad_rep_percentage(previous.rep_count, previous.bad_rep_count)
+        if previous
+        else None
+    )
     rep_count_change = None
     bad_rep_percentage_change = None
     avg_knee_angle_change = None
@@ -133,7 +143,7 @@ def load_analytics_snapshot(sessions_dir: Path) -> AnalyticsSnapshot:
                 2,
             )
 
-    main_concern, suggested_improvement, focus_area = _build_recommendation(
+    main_concern, suggested_improvement, focus_area = build_recommendation(
         latest.most_common_issue
     )
 
@@ -211,6 +221,7 @@ def _load_analytics_sessions(
         analytics_sessions.append(
             AnalyticsSessionItem(
                 folder_name=session.folder_name,
+                valid_session=_derive_valid_session(data, rep_count),
                 rep_count=rep_count,
                 bad_rep_count=bad_rep_count,
                 avg_knee_angle=_safe_float(data.get("avg_knee_angle")),
@@ -225,55 +236,24 @@ def _load_analytics_sessions(
 
 
 def _is_meaningful_session(session: AnalyticsSessionItem) -> bool:
-    return session.rep_count > 0
+    return session.valid_session and session.rep_count > 0
 
 
-def _bad_rep_percentage(session: AnalyticsSessionItem | None) -> Optional[float]:
-    if session is None:
-        return None
-    if session.rep_count <= 0:
-        return 0.0
-    return round((session.bad_rep_count / session.rep_count) * 100.0, 2)
+def _derive_valid_session(data: Optional[dict], rep_count: Optional[int]) -> bool:
+    if not data:
+        return False
+
+    explicit_flag = _safe_bool(data.get("valid_session"))
+    if explicit_flag is not None:
+        return explicit_flag
+
+    return rep_count is not None and rep_count > 0
 
 
-def _build_recommendation(
-    issue: Optional[str],
-) -> tuple[str, str, str]:
-    normalized_issue = issue or ""
-    if normalized_issue == "too_shallow":
-        return (
-            "Depth is the main concern.",
-            "Increase squat depth and aim for a lower knee angle.",
-            "Knee bend depth",
-        )
-    if _issue_matches(normalized_issue, ("ankle", "foot", "stability")):
-        return (
-            "Ankle control is the main concern.",
-            "Improve ankle stability and foot positioning.",
-            "Ankle control",
-        )
-    if _issue_matches(normalized_issue, ("torso", "back", "lean", "posture")):
-        return (
-            "Torso posture is the main concern.",
-            "Keep torso more controlled and avoid excessive forward lean.",
-            "Torso posture",
-        )
-    if normalized_issue:
-        readable_issue = normalized_issue.replace("_", " ")
-        return (
-            f"Main concern: {readable_issue}.",
-            "Maintain current form consistency.",
-            "Consistency",
-        )
-    return (
-        "No major form issue detected.",
-        "Maintain current form consistency.",
-        "Consistency",
-    )
-
-
-def _issue_matches(issue: str, keywords: tuple[str, ...]) -> bool:
-    return any(keyword in issue for keyword in keywords)
+def _format_session_label(folder_name: str, valid_session: bool) -> str:
+    if valid_session:
+        return folder_name
+    return f"{folder_name} (incomplete)"
 
 
 def _safe_int(value) -> Optional[int]:
@@ -281,6 +261,18 @@ def _safe_int(value) -> Optional[int]:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _safe_bool(value) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes"}:
+            return True
+        if lowered in {"false", "0", "no"}:
+            return False
+    return None
 
 
 def _safe_float(value) -> Optional[float]:

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -1,12 +1,15 @@
-"""Session summary placeholder for MVP."""
+"""Session summary helpers for squat-session analytics and evidence export."""
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass, field
 from datetime import datetime
 import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
+
+from session.insights import bad_rep_percentage, build_recommendation
 
 
 @dataclass
@@ -17,21 +20,31 @@ class RepEvent:
 
 
 @dataclass
+class CompletedRep:
+    rep_index: int
+    timestamp: float
+    is_bad: bool
+    issues: List[str] = field(default_factory=list)
+    min_knee_angle: Optional[float] = None
+    min_ankle_angle: Optional[float] = None
+    max_torso_angle: Optional[float] = None
+
+
+@dataclass
 class SessionSummary:
     started_at: datetime
     rep_count: int = 0
     bad_rep_count: int = 0
     events: List[RepEvent] = field(default_factory=list)
+    completed_reps: List[CompletedRep] = field(default_factory=list)
     knee_angles: List[float] = field(default_factory=list)
     ankle_angles: List[float] = field(default_factory=list)
     torso_angles: List[float] = field(default_factory=list)
+    fps_samples: List[float] = field(default_factory=list)
     issue_counts: Dict[str, int] = field(default_factory=dict)
 
     def add_event(self, timestamp: float, label: str, reason: str = "") -> None:
         self.events.append(RepEvent(timestamp=timestamp, label=label, reason=reason))
-
-    def add_knee_angle(self, angle: float) -> None:
-        self.knee_angles.append(angle)
 
     def add_pose_metrics(
         self,
@@ -47,9 +60,19 @@ class SessionSummary:
         if torso_angle is not None:
             self.torso_angles.append(torso_angle)
 
+    def add_fps_sample(self, fps: float) -> None:
+        if fps > 0:
+            self.fps_samples.append(fps)
+
+    def record_issues(self, issues: Sequence[str]) -> None:
+        for issue in issues:
+            issue_name = issue.strip()
+            if not issue_name:
+                continue
+            self.issue_counts[issue_name] = self.issue_counts.get(issue_name, 0) + 1
+
     def record_issue(self, reason: str) -> None:
-        for issue in self._split_issues(reason):
-            self.issue_counts[issue] = self.issue_counts.get(issue, 0) + 1
+        self.record_issues(self._split_issues(reason))
 
     def record_rep_start(self, timestamp: float) -> None:
         self.add_event(timestamp=timestamp, label="rep_start")
@@ -57,18 +80,59 @@ class SessionSummary:
     def record_rep_complete(self, timestamp: float, reason: str = "") -> None:
         self.add_event(timestamp=timestamp, label="rep_complete", reason=reason)
 
+    def record_completed_rep(
+        self,
+        *,
+        rep_index: int,
+        timestamp: float,
+        is_bad: bool,
+        issues: Sequence[str],
+        min_knee_angle: Optional[float],
+        min_ankle_angle: Optional[float],
+        max_torso_angle: Optional[float],
+    ) -> None:
+        self.completed_reps.append(
+            CompletedRep(
+                rep_index=rep_index,
+                timestamp=timestamp,
+                is_bad=is_bad,
+                issues=list(issues),
+                min_knee_angle=self._round_optional(min_knee_angle),
+                min_ankle_angle=self._round_optional(min_ankle_angle),
+                max_torso_angle=self._round_optional(max_torso_angle),
+            )
+        )
+
     def to_dict(self) -> dict:
+        valid_session = self.rep_count > 0
         return {
             "started_at": self.started_at.isoformat(),
+            "valid_session": valid_session,
             "rep_count": self.rep_count,
             "bad_rep_count": self.bad_rep_count,
-            "avg_knee_angle": self._average_knee_angle(),
-            "min_knee_angle": self._minimum_knee_angle(),
-            "avg_ankle_angle": self._average_ankle_angle(),
-            "min_ankle_angle": self._minimum_ankle_angle(),
-            "avg_torso_angle": self._average_torso_angle(),
+            "avg_fps": self._average_value(self.fps_samples),
+            "min_fps": self._minimum_value(self.fps_samples),
+            "max_fps": self._maximum_value(self.fps_samples),
+            "avg_knee_angle": self._average_value(self.knee_angles),
+            "min_knee_angle": self._minimum_value(self.knee_angles),
+            "avg_ankle_angle": self._average_value(self.ankle_angles),
+            "min_ankle_angle": self._minimum_value(self.ankle_angles),
+            "avg_torso_angle": self._average_value(self.torso_angles),
+            "max_torso_angle": self._maximum_value(self.torso_angles),
             "issue_counts": dict(sorted(self.issue_counts.items())),
             "most_common_issue": self._most_common_issue(),
+            "completed_reps": [
+                {
+                    "rep_index": rep.rep_index,
+                    "timestamp": rep.timestamp,
+                    "is_bad": rep.is_bad,
+                    "issues": list(rep.issues),
+                    "min_knee_angle": rep.min_knee_angle,
+                    "min_ankle_angle": rep.min_ankle_angle,
+                    "max_torso_angle": rep.max_torso_angle,
+                }
+                for rep in self.completed_reps
+            ],
             "events": [
                 {
                     "timestamp": event.timestamp,
@@ -81,25 +145,73 @@ class SessionSummary:
 
     def save(self, output_dir: Path) -> Path:
         output_dir.mkdir(parents=True, exist_ok=True)
-        output_path = output_dir / "summary.json"
-        with output_path.open("w", encoding="utf-8") as file:
-            json.dump(self.to_dict(), file, indent=2)
-        return output_path
 
-    def _average_knee_angle(self) -> Optional[float]:
-        return self._average_value(self.knee_angles)
+        summary_data = self.to_dict()
+        summary_path = output_dir / "summary.json"
+        with summary_path.open("w", encoding="utf-8") as file:
+            json.dump(summary_data, file, indent=2)
 
-    def _minimum_knee_angle(self) -> Optional[float]:
-        return self._minimum_value(self.knee_angles)
+        self._save_rep_metrics_csv(output_dir / "rep_metrics.csv")
+        self._save_session_report(output_dir / "session_report.txt", summary_data)
+        return summary_path
 
-    def _average_ankle_angle(self) -> Optional[float]:
-        return self._average_value(self.ankle_angles)
+    def _save_rep_metrics_csv(self, output_path: Path) -> None:
+        with output_path.open("w", encoding="utf-8", newline="") as file:
+            writer = csv.writer(file)
+            writer.writerow(
+                [
+                    "rep_index",
+                    "timestamp_seconds",
+                    "is_bad",
+                    "issues",
+                    "min_knee_angle",
+                    "min_ankle_angle",
+                    "max_torso_angle",
+                ]
+            )
+            for rep in self.completed_reps:
+                writer.writerow(
+                    [
+                        rep.rep_index,
+                        f"{rep.timestamp:.2f}",
+                        int(rep.is_bad),
+                        ", ".join(rep.issues),
+                        self._format_optional(rep.min_knee_angle),
+                        self._format_optional(rep.min_ankle_angle),
+                        self._format_optional(rep.max_torso_angle),
+                    ]
+                )
 
-    def _minimum_ankle_angle(self) -> Optional[float]:
-        return self._minimum_value(self.ankle_angles)
-
-    def _average_torso_angle(self) -> Optional[float]:
-        return self._average_value(self.torso_angles)
+    def _save_session_report(self, output_path: Path, summary_data: dict) -> None:
+        main_concern, suggested_improvement, focus_area = build_recommendation(
+            summary_data.get("most_common_issue")
+        )
+        valid_session = bool(summary_data.get("valid_session"))
+        lines = [
+            "GymGuardian Session Report",
+            f"Started at: {summary_data.get('started_at', 'N/A')}",
+            f"Session status: {'valid' if valid_session else 'incomplete'}",
+            f"Total reps: {summary_data.get('rep_count', 0)}",
+            f"Bad reps: {summary_data.get('bad_rep_count', 0)}",
+            (
+                "Bad rep rate: "
+                f"{bad_rep_percentage(self.rep_count, self.bad_rep_count):.2f}%"
+            ),
+            f"Average FPS: {self._display_metric(summary_data.get('avg_fps'))}",
+            f"Minimum FPS: {self._display_metric(summary_data.get('min_fps'))}",
+            f"Maximum FPS: {self._display_metric(summary_data.get('max_fps'))}",
+            f"Average knee angle: {self._display_metric(summary_data.get('avg_knee_angle'))}",
+            f"Minimum knee angle: {self._display_metric(summary_data.get('min_knee_angle'))}",
+            f"Average ankle angle: {self._display_metric(summary_data.get('avg_ankle_angle'))}",
+            f"Minimum ankle angle: {self._display_metric(summary_data.get('min_ankle_angle'))}",
+            f"Average torso angle: {self._display_metric(summary_data.get('avg_torso_angle'))}",
+            f"Maximum torso angle: {self._display_metric(summary_data.get('max_torso_angle'))}",
+            f"Most common issue: {summary_data.get('most_common_issue') or 'none'}",
+            f"Main concern: {main_concern}",
+            f"Suggested improvement: {suggested_improvement}",
+            f"Focus area: {focus_area}",
+        ]
+        output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     def _most_common_issue(self) -> Optional[str]:
         if not self.issue_counts:
@@ -125,3 +237,27 @@ class SessionSummary:
         if not values:
             return None
         return round(min(values), 2)
+
+    @staticmethod
+    def _maximum_value(values: List[float]) -> Optional[float]:
+        if not values:
+            return None
+        return round(max(values), 2)
+
+    @staticmethod
+    def _round_optional(value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        return round(value, 2)
+
+    @staticmethod
+    def _format_optional(value: Optional[float]) -> str:
+        if value is None:
+            return ""
+        return f"{value:.2f}"
+
+    @staticmethod
+    def _display_metric(value: Optional[float]) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.2f}"

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -486,7 +486,7 @@ class OverlayRenderer:
             third_row_y,
             card_w,
             issue_h,
-            "Torso Posture Metric",
+            "Avg Torso Lean",
             self._format_angle(snapshot.latest_avg_torso_angle),
             self.TEXT,
             value_scale=0.62 if compact_layout else 0.68,
@@ -655,19 +655,34 @@ class OverlayRenderer:
         else:
             lines.append(f"Knee angle: {knee_angle:.1f}")
 
+        ankle_angle = debug_info.get("ankle_angle")
+        if ankle_angle is None:
+            lines.append("Ankle angle: n/a")
+        else:
+            lines.append(f"Ankle angle: {ankle_angle:.1f}")
+
+        torso_angle = debug_info.get("torso_angle")
+        if torso_angle is None:
+            lines.append("Torso angle: n/a")
+        else:
+            lines.append(f"Torso angle: {torso_angle:.1f}")
+
         lines.extend(
             [
                 f"down_knee_angle: {debug_info.get('down_knee_angle')}",
                 f"up_knee_angle: {debug_info.get('up_knee_angle')}",
                 f"rep_bottom_knee_angle: {debug_info.get('rep_bottom_knee_angle')}",
                 f"shallow_knee_angle: {debug_info.get('shallow_knee_angle')}",
+                f"ankle_control_angle: {debug_info.get('ankle_control_angle')}",
+                f"torso_lean_angle: {debug_info.get('torso_lean_angle')}",
                 f"down_hold_frames: {debug_info.get('down_hold_frames')}",
+                f"ready_standing_frames: {debug_info.get('ready_standing_frames')}",
                 f"min_rep_seconds: {debug_info.get('min_rep_seconds')}",
             ]
         )
 
         panel_x = 20
-        panel_y = 194
+        panel_y = 260
         line_height = 26
         panel_w = 460
         panel_h = 24 + line_height * len(lines)
@@ -712,7 +727,7 @@ class OverlayRenderer:
         panel_x = 20
         panel_y = 20
         panel_w = 470
-        panel_h = 184
+        panel_h = 228
         pad = 18
 
         self._draw_panel(
@@ -752,10 +767,34 @@ class OverlayRenderer:
             max_width=panel_w - (pad * 2),
         )
 
+        ankle_text = self._format_angle_metric("Ankle angle", squat_state.ankle_angle)
+        self._put_text(
+            frame_bgr,
+            ankle_text,
+            panel_x + pad,
+            panel_y + 102,
+            scale=0.58,
+            color=self.TEXT,
+            thickness=1,
+            max_width=panel_w - (pad * 2),
+        )
+
+        torso_text = self._format_angle_metric("Torso lean", squat_state.torso_angle)
+        self._put_text(
+            frame_bgr,
+            torso_text,
+            panel_x + pad,
+            panel_y + 130,
+            scale=0.58,
+            color=self.TEXT,
+            thickness=1,
+            max_width=panel_w - (pad * 2),
+        )
+
         if rep_counter is None:
             return
 
-        reps_y = panel_y + 112
+        reps_y = panel_y + 164
         self._put_text(
             frame_bgr,
             f"Reps: {rep_counter.rep_count}",
@@ -782,7 +821,7 @@ class OverlayRenderer:
             frame_bgr,
             f"Last: {last_text}",
             panel_x + pad,
-            panel_y + 144,
+            panel_y + 196,
             scale=0.56,
             color=self.MUTED,
             thickness=1,
@@ -792,7 +831,7 @@ class OverlayRenderer:
             frame_bgr,
             "Esc: end session    D: debug overlay",
             panel_x + pad,
-            panel_y + 170,
+            panel_y + 214,
             scale=0.48,
             color=self.MUTED,
             thickness=1,
@@ -1090,6 +1129,12 @@ class OverlayRenderer:
         if value is None:
             return "N/A"
         return f"{value:+.1f} pts"
+
+    @staticmethod
+    def _format_angle_metric(label: str, value: float | None) -> str:
+        if value is None:
+            return f"{label}: n/a"
+        return f"{label}: {value:.1f} deg"
 
     @staticmethod
     def _format_angle(value: float | None) -> str:


### PR DESCRIPTION
Closes #38 

What changed:
- Marked empty sessions as invalid.
- Prevented invalid sessions from affecting analytics.
- Preserved valid session recording and summary saving.

How to test:
python src/app.py

Test steps:
- Start a session and exit immediately.
- Confirm summary.json marks the session as invalid.
- Open analytics dashboard and confirm the empty session does not affect meaningful-session metrics.
- Run a valid session and confirm it appears normally.