### PR TITLE
feat: add user calibration for adaptive thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ data/*.avi
 assets/models/*.task
 
 sessions/
+user_data/

--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import math
 from typing import Deque, Optional
 
-from core.config import SQUAT_CONFIG
+from core.config import SQUAT_CONFIG, SquatConfig
 
 
 @dataclass(frozen=True)
@@ -22,8 +22,9 @@ class SquatState:
 class SquatStateAnalyzer:
     """Classify squat state from pose landmarks with light smoothing."""
 
-    def __init__(self) -> None:
-        window = max(1, SQUAT_CONFIG.angle_smoothing_window)
+    def __init__(self, config: SquatConfig | None = None) -> None:
+        self._config = config or SQUAT_CONFIG
+        window = max(1, self._config.angle_smoothing_window)
         self._knee_history: Deque[float] = deque(maxlen=window)
         self._ankle_history: Deque[float] = deque(maxlen=window)
         self._torso_history: Deque[float] = deque(maxlen=window)
@@ -59,9 +60,9 @@ class SquatStateAnalyzer:
         )
 
         self._missing_pose_frames = 0
-        if knee_angle <= SQUAT_CONFIG.down_knee_angle:
+        if knee_angle <= self._config.down_knee_angle:
             label = "down"
-        elif knee_angle >= SQUAT_CONFIG.up_knee_angle:
+        elif knee_angle >= self._config.up_knee_angle:
             label = "standing"
         else:
             label = "transition"
@@ -125,15 +126,14 @@ class SquatStateAnalyzer:
 
     def _mark_missing_pose(self) -> None:
         self._missing_pose_frames += 1
-        if self._missing_pose_frames >= SQUAT_CONFIG.no_pose_reset_frames:
+        if self._missing_pose_frames >= self._config.no_pose_reset_frames:
             self._knee_history.clear()
             self._ankle_history.clear()
             self._torso_history.clear()
 
-    @staticmethod
-    def _landmarks_visible(landmarks, *indices: int) -> bool:
+    def _landmarks_visible(self, landmarks, *indices: int) -> bool:
         visibilities = [getattr(landmarks[index], "visibility", 1.0) for index in indices]
-        return min(visibilities) >= SQUAT_CONFIG.landmark_visibility_threshold
+        return min(visibilities) >= self._config.landmark_visibility_threshold
 
 
 
@@ -167,7 +167,8 @@ class RepCounterUpdate:
 class SquatRepCounter:
     """Track squat reps while keeping quality checks rule-based and separate."""
 
-    def __init__(self) -> None:
+    def __init__(self, config: SquatConfig | None = None) -> None:
+        self._config = config or SQUAT_CONFIG
         self.rep_count = 0
         self.bad_rep_count = 0
         self.last_rep_result = "none"
@@ -191,9 +192,9 @@ class SquatRepCounter:
 
         self._missing_pose_frames = 0
 
-        if angle >= SQUAT_CONFIG.up_knee_angle:
+        if angle >= self._config.up_knee_angle:
             self._standing_frames += 1
-            if not self._in_rep and self._standing_frames >= SQUAT_CONFIG.ready_standing_frames:
+            if not self._in_rep and self._standing_frames >= self._config.ready_standing_frames:
                 self._ready_for_rep = True
                 self._bottom_frames = 0
                 self._clear_cycle_metrics()
@@ -203,8 +204,8 @@ class SquatRepCounter:
         if self._in_rep:
             self._update_cycle_metrics(squat_state)
             if (
-                timestamp - self._rep_start_time >= SQUAT_CONFIG.min_rep_seconds
-                and angle >= SQUAT_CONFIG.up_knee_angle
+                timestamp - self._rep_start_time >= self._config.min_rep_seconds
+                and angle >= self._config.up_knee_angle
             ):
                 return self._complete_rep()
             return RepCounterUpdate()
@@ -212,12 +213,12 @@ class SquatRepCounter:
         if not self._ready_for_rep:
             return RepCounterUpdate()
 
-        if angle < SQUAT_CONFIG.up_knee_angle:
+        if angle < self._config.up_knee_angle:
             self._update_cycle_metrics(squat_state)
 
-        if angle <= SQUAT_CONFIG.rep_bottom_knee_angle:
+        if angle <= self._config.rep_bottom_knee_angle:
             self._bottom_frames += 1
-            if self._bottom_frames >= SQUAT_CONFIG.down_hold_frames:
+            if self._bottom_frames >= self._config.down_hold_frames:
                 self._in_rep = True
                 self._rep_start_time = timestamp
                 return RepCounterUpdate(
@@ -226,7 +227,7 @@ class SquatRepCounter:
                     min_ankle_angle=self._min_ankle_angle,
                     max_torso_angle=self._max_torso_angle,
                 )
-        elif angle >= SQUAT_CONFIG.down_knee_angle:
+        elif angle >= self._config.down_knee_angle:
             self._bottom_frames = 0
 
         return RepCounterUpdate()
@@ -235,7 +236,7 @@ class SquatRepCounter:
         self._bottom_frames = 0
         self._standing_frames = 0
         self._missing_pose_frames += 1
-        if self._missing_pose_frames >= SQUAT_CONFIG.no_pose_reset_frames:
+        if self._missing_pose_frames >= self._config.no_pose_reset_frames:
             self._reset_cycle_state()
         return RepCounterUpdate()
 
@@ -267,16 +268,16 @@ class SquatRepCounter:
         max_torso_angle = self._max_torso_angle
 
         issues: list[str] = []
-        if min_knee_angle is None or min_knee_angle > SQUAT_CONFIG.shallow_knee_angle:
+        if min_knee_angle is None or min_knee_angle > self._config.shallow_knee_angle:
             issues.append("too_shallow")
         if (
             min_ankle_angle is not None
-            and min_ankle_angle > SQUAT_CONFIG.ankle_control_angle
+            and min_ankle_angle > self._config.ankle_control_angle
         ):
             issues.append("ankle_control")
         if (
             max_torso_angle is not None
-            and max_torso_angle > SQUAT_CONFIG.torso_lean_angle
+            and max_torso_angle > self._config.torso_lean_angle
         ):
             issues.append("torso_lean")
 

--- a/src/app.py
+++ b/src/app.py
@@ -12,8 +12,15 @@ import cv2
 import numpy as np
 
 from analysis.squat import SquatRepCounter, SquatStateAnalyzer
-from core.config import SQUAT_CONFIG
+from core.config import CALIBRATION_CONFIG, SquatConfig
 from core.paths import SESSIONS_DIR
+from core.user_profile import (
+    build_calibration_profile,
+    load_calibration_profile,
+    load_squat_config,
+    reset_calibration_profile,
+    save_calibration_profile,
+)
 from pose.detector import PoseDetector
 from session.browser import (
     list_recent_sessions,
@@ -34,6 +41,7 @@ STATE_DASHBOARD = "dashboard"
 STATE_SESSION = "session"
 STATE_BROWSE = "browse"
 STATE_ANALYTICS = "analytics"
+STATE_CALIBRATION = "calibration"
 UP_KEY = 2490368
 DOWN_KEY = 2621440
 FEEDBACK_HOLD_SECONDS = 2.0
@@ -189,6 +197,7 @@ def _current_feedback(
     feedback_level: str,
     feedback_until: float,
     timestamp: float,
+    squat_config: SquatConfig,
 ) -> tuple[str | None, str]:
     if feedback_message and timestamp <= feedback_until:
         return feedback_message, feedback_level
@@ -196,7 +205,7 @@ def _current_feedback(
     angle = squat_state.knee_angle
     if (
         angle is not None
-        and SQUAT_CONFIG.shallow_knee_angle < angle <= SQUAT_CONFIG.rep_bottom_knee_angle
+        and squat_config.shallow_knee_angle < angle <= squat_config.rep_bottom_knee_angle
     ):
         return "Go deeper", "warning"
 
@@ -215,6 +224,26 @@ def _rep_feedback(issues: tuple[str, ...], is_bad: bool) -> tuple[str, str]:
     return "Rep accepted", "ok"
 
 
+def _calibration_status(
+    *,
+    phase: str,
+    sample_count: int = 0,
+    elapsed: float = 0.0,
+    message: str = "",
+    error: str = "",
+    profile=None,
+) -> dict:
+    return {
+        "phase": phase,
+        "sample_count": sample_count,
+        "elapsed": elapsed,
+        "duration": CALIBRATION_CONFIG.collection_seconds,
+        "message": message,
+        "error": error,
+        "profile": profile,
+    }
+
+
 def run_session(overlay: OverlayRenderer) -> bool:
     """Run one workout session and persist outputs on exit."""
     cap = cv2.VideoCapture(0)
@@ -228,8 +257,9 @@ def run_session(overlay: OverlayRenderer) -> bool:
     cap.set(cv2.CAP_PROP_FPS, 30)
 
     detector = PoseDetector()
-    analyzer = SquatStateAnalyzer()
-    rep_counter = SquatRepCounter()
+    squat_config = load_squat_config()
+    analyzer = SquatStateAnalyzer(squat_config)
+    rep_counter = SquatRepCounter(squat_config)
     summary = SessionSummary(started_at=datetime.now())
     session_dir = SESSIONS_DIR / summary.started_at.strftime("%Y%m%d_%H%M%S")
     recorder = SessionRecorder(session_dir)
@@ -312,6 +342,7 @@ def run_session(overlay: OverlayRenderer) -> bool:
                 feedback_level,
                 feedback_until,
                 timestamp,
+                squat_config,
             )
             overlay.draw(
                 frame,
@@ -333,15 +364,15 @@ def run_session(overlay: OverlayRenderer) -> bool:
                     "knee_angle": squat_state.knee_angle,
                     "ankle_angle": squat_state.ankle_angle,
                     "torso_angle": squat_state.torso_angle,
-                    "down_knee_angle": SQUAT_CONFIG.down_knee_angle,
-                    "up_knee_angle": SQUAT_CONFIG.up_knee_angle,
-                    "rep_bottom_knee_angle": SQUAT_CONFIG.rep_bottom_knee_angle,
-                    "shallow_knee_angle": SQUAT_CONFIG.shallow_knee_angle,
-                    "ankle_control_angle": SQUAT_CONFIG.ankle_control_angle,
-                    "torso_lean_angle": SQUAT_CONFIG.torso_lean_angle,
-                    "down_hold_frames": SQUAT_CONFIG.down_hold_frames,
-                    "ready_standing_frames": SQUAT_CONFIG.ready_standing_frames,
-                    "min_rep_seconds": SQUAT_CONFIG.min_rep_seconds,
+                    "down_knee_angle": squat_config.down_knee_angle,
+                    "up_knee_angle": squat_config.up_knee_angle,
+                    "rep_bottom_knee_angle": squat_config.rep_bottom_knee_angle,
+                    "shallow_knee_angle": squat_config.shallow_knee_angle,
+                    "ankle_control_angle": squat_config.ankle_control_angle,
+                    "torso_lean_angle": squat_config.torso_lean_angle,
+                    "down_hold_frames": squat_config.down_hold_frames,
+                    "ready_standing_frames": squat_config.ready_standing_frames,
+                    "min_rep_seconds": squat_config.min_rep_seconds,
                 }
                 overlay.draw_debug(frame, debug_info)
             recorder.write(frame)
@@ -430,6 +461,125 @@ def run_analytics(overlay: OverlayRenderer) -> bool:
             snapshot = load_analytics_snapshot(SESSIONS_DIR)
 
 
+def run_calibration(overlay: OverlayRenderer) -> bool:
+    """Collect a short calibration set and save user-specific squat thresholds."""
+    cap = cv2.VideoCapture(0)
+    profile = load_calibration_profile()
+
+    if not cap.isOpened():
+        cap.release()
+        status = _calibration_status(
+            phase="error",
+            message="Could not open webcam for calibration.",
+            profile=profile,
+        )
+        while True:
+            if not _window_is_open(WINDOW_NAME):
+                return False
+            frame = _blank_screen()
+            overlay.draw_calibration(frame, None, None, status)
+            _show_frame(WINDOW_NAME, frame)
+            key = _wait_for_key_or_close(STATIC_SCREEN_WAIT_MS)
+            if key is None:
+                return False
+            if key == -1:
+                continue
+            if key == 27:
+                return True
+            if key in (ord("r"), ord("R")):
+                reset_calibration_profile()
+                profile = None
+                status = _calibration_status(
+                    phase="reset",
+                    message="Calibration reset. Defaults will be used.",
+                    profile=profile,
+                )
+
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, FRAME_WIDTH)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT)
+    cap.set(cv2.CAP_PROP_FPS, 30)
+
+    detector = PoseDetector()
+    analyzer = SquatStateAnalyzer()
+    knee_samples: list[float] = []
+    started_at = time.time()
+    saved = False
+    message = "Perform 2-3 normal squats. The app will save automatically."
+    phase = "collecting"
+
+    try:
+        while True:
+            if not _window_is_open(WINDOW_NAME):
+                return False
+
+            ok, frame = cap.read()
+            if not ok:
+                phase = "error"
+                message = "Camera frame unavailable. Press Esc to return."
+                frame = _blank_screen()
+                results = None
+                squat_state = None
+            else:
+                results = detector.process(frame)
+                squat_state = analyzer.classify(results)
+                if (
+                    phase == "collecting"
+                    and squat_state.pose_visible
+                    and squat_state.knee_angle is not None
+                ):
+                    knee_samples.append(squat_state.knee_angle)
+
+            elapsed = time.time() - started_at
+            if (
+                phase == "collecting"
+                and elapsed >= CALIBRATION_CONFIG.collection_seconds
+            ):
+                try:
+                    profile = build_calibration_profile(knee_samples)
+                    save_calibration_profile(profile)
+                    phase = "saved"
+                    saved = True
+                    message = "Calibration saved. Press Esc to return or R to reset."
+                except ValueError as exc:
+                    phase = "failed"
+                    message = f"{exc} Press R to retry or Esc to return."
+
+            status = _calibration_status(
+                phase=phase,
+                sample_count=len(knee_samples),
+                elapsed=elapsed,
+                message=message,
+                profile=profile,
+            )
+            overlay.draw_calibration(frame, results, squat_state, status)
+            _show_frame(WINDOW_NAME, frame)
+
+            key = _wait_for_key_or_close(1 if phase == "collecting" else STATIC_SCREEN_WAIT_MS)
+            if key is None:
+                return False
+            if key == -1:
+                continue
+            if key == 27:
+                return True
+            if key in (ord("r"), ord("R")):
+                reset_calibration_profile()
+                profile = None
+                knee_samples.clear()
+                started_at = time.time()
+                saved = False
+                phase = "collecting"
+                message = "Calibration reset. Perform 2-3 normal squats again."
+            elif key in (ord("c"), ord("C")) and saved:
+                knee_samples.clear()
+                started_at = time.time()
+                saved = False
+                phase = "collecting"
+                message = "Recalibrating. Perform 2-3 normal squats."
+    finally:
+        detector.close()
+        cap.release()
+
+
 def main() -> None:
     overlay = OverlayRenderer()
     state = STATE_DASHBOARD
@@ -442,7 +592,7 @@ def main() -> None:
 
             if state == STATE_DASHBOARD:
                 frame = _blank_screen()
-                overlay.draw_dashboard(frame)
+                overlay.draw_dashboard(frame, load_calibration_profile())
                 _show_frame(WINDOW_NAME, frame)
                 key = _wait_for_key_or_close(STATIC_SCREEN_WAIT_MS)
 
@@ -452,6 +602,8 @@ def main() -> None:
                     continue
                 if key in (ord("s"), ord("S")):
                     state = STATE_SESSION
+                elif key in (ord("c"), ord("C")):
+                    state = STATE_CALIBRATION
                 elif key in (ord("b"), ord("B")):
                     state = STATE_BROWSE
                 elif key in (ord("a"), ord("A")):
@@ -468,6 +620,10 @@ def main() -> None:
                 state = STATE_DASHBOARD
             elif state == STATE_ANALYTICS:
                 if not run_analytics(overlay):
+                    break
+                state = STATE_DASHBOARD
+            elif state == STATE_CALIBRATION:
+                if not run_calibration(overlay):
                     break
                 state = STATE_DASHBOARD
     finally:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -29,5 +29,25 @@ class SquatConfig:
     min_rep_seconds: float = 0.6
 
 
+@dataclass(frozen=True)
+class CalibrationConfig:
+    collection_seconds: float = 12.0
+    min_samples: int = 30
+    min_movement_range: float = 25.0
+    down_margin_ratio: float = 0.12
+    shallow_margin_ratio: float = 0.20
+    rep_bottom_margin_ratio: float = 0.45
+    up_margin_ratio: float = 0.08
+    min_down_margin: float = 6.0
+    max_down_margin: float = 12.0
+    min_shallow_margin: float = 14.0
+    max_shallow_margin: float = 25.0
+    min_rep_bottom_margin: float = 30.0
+    max_rep_bottom_margin: float = 50.0
+    min_up_margin: float = 6.0
+    max_up_margin: float = 12.0
+
+
 POSE_CONFIG = PoseConfig()
 SQUAT_CONFIG = SquatConfig()
+CALIBRATION_CONFIG = CalibrationConfig()

--- a/src/core/user_profile.py
+++ b/src/core/user_profile.py
@@ -1,0 +1,148 @@
+"""Local user calibration storage for adaptive squat thresholds."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime
+import json
+from pathlib import Path
+
+from core.config import CALIBRATION_CONFIG, SQUAT_CONFIG, SquatConfig
+from core.paths import PROJECT_ROOT
+
+
+PROFILE_DIR = PROJECT_ROOT / "user_data"
+CALIBRATION_FILE = PROFILE_DIR / "calibration.json"
+
+
+@dataclass(frozen=True)
+class CalibrationProfile:
+    created_at: str
+    sample_count: int
+    standing_knee_angle: float
+    lowest_knee_angle: float
+    calibrated_down_angle: float
+    calibrated_shallow_angle: float
+    calibrated_rep_bottom_angle: float
+    calibrated_up_angle: float
+
+    def to_squat_config(self) -> SquatConfig:
+        return replace(
+            SQUAT_CONFIG,
+            down_knee_angle=self.calibrated_down_angle,
+            shallow_knee_angle=self.calibrated_shallow_angle,
+            rep_bottom_knee_angle=self.calibrated_rep_bottom_angle,
+            up_knee_angle=self.calibrated_up_angle,
+        )
+
+
+def load_calibration_profile() -> CalibrationProfile | None:
+    if not CALIBRATION_FILE.exists():
+        return None
+
+    try:
+        data = json.loads(CALIBRATION_FILE.read_text(encoding="utf-8"))
+        return CalibrationProfile(
+            created_at=str(data["created_at"]),
+            sample_count=int(data["sample_count"]),
+            standing_knee_angle=float(data["standing_knee_angle"]),
+            lowest_knee_angle=float(data["lowest_knee_angle"]),
+            calibrated_down_angle=float(data["calibrated_down_angle"]),
+            calibrated_shallow_angle=float(data["calibrated_shallow_angle"]),
+            calibrated_rep_bottom_angle=float(data["calibrated_rep_bottom_angle"]),
+            calibrated_up_angle=float(data["calibrated_up_angle"]),
+        )
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def save_calibration_profile(profile: CalibrationProfile) -> Path:
+    PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    CALIBRATION_FILE.write_text(
+        json.dumps(asdict(profile), indent=2),
+        encoding="utf-8",
+    )
+    return CALIBRATION_FILE
+
+
+def reset_calibration_profile() -> None:
+    try:
+        CALIBRATION_FILE.unlink()
+    except FileNotFoundError:
+        return
+
+
+def load_squat_config() -> SquatConfig:
+    profile = load_calibration_profile()
+    if profile is None:
+        return SQUAT_CONFIG
+    return profile.to_squat_config()
+
+
+def build_calibration_profile(knee_angles: list[float]) -> CalibrationProfile:
+    valid_angles = [angle for angle in knee_angles if 30.0 <= angle <= 180.0]
+    if len(valid_angles) < CALIBRATION_CONFIG.min_samples:
+        raise ValueError("Not enough valid knee-angle samples.")
+
+    sorted_angles = sorted(valid_angles)
+    bucket_size = max(3, len(sorted_angles) // 5)
+    lowest_knee_angle = _mean(sorted_angles[:bucket_size])
+    standing_knee_angle = _mean(sorted_angles[-bucket_size:])
+    movement_range = standing_knee_angle - lowest_knee_angle
+
+    if movement_range < CALIBRATION_CONFIG.min_movement_range:
+        raise ValueError("Movement range too small for reliable calibration.")
+
+    down_margin = _clamp(
+        movement_range * CALIBRATION_CONFIG.down_margin_ratio,
+        CALIBRATION_CONFIG.min_down_margin,
+        CALIBRATION_CONFIG.max_down_margin,
+    )
+    shallow_margin = _clamp(
+        movement_range * CALIBRATION_CONFIG.shallow_margin_ratio,
+        CALIBRATION_CONFIG.min_shallow_margin,
+        CALIBRATION_CONFIG.max_shallow_margin,
+    )
+    rep_bottom_margin = _clamp(
+        movement_range * CALIBRATION_CONFIG.rep_bottom_margin_ratio,
+        CALIBRATION_CONFIG.min_rep_bottom_margin,
+        CALIBRATION_CONFIG.max_rep_bottom_margin,
+    )
+    up_margin = _clamp(
+        movement_range * CALIBRATION_CONFIG.up_margin_ratio,
+        CALIBRATION_CONFIG.min_up_margin,
+        CALIBRATION_CONFIG.max_up_margin,
+    )
+
+    calibrated_up_angle = standing_knee_angle - up_margin
+    calibrated_down_angle = min(
+        lowest_knee_angle + down_margin,
+        calibrated_up_angle - 35.0,
+    )
+    calibrated_shallow_angle = min(
+        max(calibrated_down_angle + 5.0, lowest_knee_angle + shallow_margin),
+        calibrated_up_angle - 20.0,
+    )
+    calibrated_rep_bottom_angle = min(
+        max(calibrated_shallow_angle + 10.0, lowest_knee_angle + rep_bottom_margin),
+        calibrated_up_angle - 8.0,
+    )
+
+    return CalibrationProfile(
+        created_at=datetime.now().isoformat(timespec="seconds"),
+        sample_count=len(valid_angles),
+        standing_knee_angle=round(standing_knee_angle, 1),
+        lowest_knee_angle=round(lowest_knee_angle, 1),
+        calibrated_down_angle=round(calibrated_down_angle, 1),
+        calibrated_shallow_angle=round(calibrated_shallow_angle, 1),
+        calibrated_rep_bottom_angle=round(calibrated_rep_bottom_angle, 1),
+        calibrated_up_angle=round(calibrated_up_angle, 1),
+    )
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -60,7 +60,7 @@ class OverlayRenderer:
             feedback_level,
         )
 
-    def draw_dashboard(self, frame_bgr) -> None:
+    def draw_dashboard(self, frame_bgr, calibration_profile=None) -> None:
         self._fill_background(frame_bgr)
         frame_h, frame_w = frame_bgr.shape[:2]
 
@@ -130,22 +130,23 @@ class OverlayRenderer:
             insight_x + insight_w + insight_gap,
             insight_y,
             insight_w,
-            "Processing",
-            "Local webcam pipeline",
+            "Calibration",
+            "Adaptive thresholds" if calibration_profile else "Default thresholds",
         )
 
         options = [
             ("S", "Start squat session", "Open webcam and begin form tracking"),
+            ("C", "Calibrate squat depth", "Personalise thresholds with 2-3 squats"),
             ("A", "Open analytics dashboard", "View progress and recommendations"),
             ("B", "Browse saved sessions", "Review videos and session files"),
             ("Esc", "Quit application", "Close GymGuardian"),
         ]
 
-        card_gap = 18
+        card_gap = 14
         cards_x = shell_x + 58
-        cards_y = shell_y + 246
+        cards_y = shell_y + 236
         card_w = (shell_w - 116 - card_gap) // 2
-        card_h = 84
+        card_h = 70
         for index, (key, title, subtitle) in enumerate(options):
             col = index % 2
             row = index // 2
@@ -506,6 +507,155 @@ class OverlayRenderer:
             report_w,
             lower_h,
             snapshot,
+        )
+
+    def draw_calibration(self, frame_bgr, results, squat_state, status: dict) -> None:
+        if results is not None:
+            self._draw_pose_points(frame_bgr, results)
+        elif frame_bgr.mean() < 5:
+            self._fill_background(frame_bgr)
+
+        frame_h, frame_w = frame_bgr.shape[:2]
+        panel_w = min(620, frame_w - 56)
+        panel_h = 330
+        panel_x = 28
+        panel_y = 30
+        phase = status.get("phase", "collecting")
+        profile = status.get("profile")
+        elapsed = float(status.get("elapsed", 0.0))
+        duration = float(status.get("duration", 1.0))
+        progress = min(1.0, elapsed / max(1.0, duration))
+
+        self._draw_panel(
+            frame_bgr,
+            panel_x,
+            panel_y,
+            panel_w,
+            panel_h,
+            color=self.LIVE_PANEL,
+            border_color=self.LIVE_BORDER,
+            alpha=0.88,
+            radius=20,
+        )
+
+        self._put_text(
+            frame_bgr,
+            "Squat Depth Calibration",
+            panel_x + 24,
+            panel_y + 42,
+            0.72,
+            self.LIVE_TEXT,
+            2,
+            max_width=panel_w - 48,
+        )
+        self._put_text(
+            frame_bgr,
+            "Perform 2-3 normal squats. Keep your lower body visible.",
+            panel_x + 24,
+            panel_y + 72,
+            0.42,
+            self.LIVE_MUTED,
+            max_width=panel_w - 48,
+        )
+
+        bar_x = panel_x + 24
+        bar_y = panel_y + 96
+        bar_w = panel_w - 48
+        self._draw_panel(
+            frame_bgr,
+            bar_x,
+            bar_y,
+            bar_w,
+            16,
+            color=self.LIVE_CARD,
+            border_color=(78, 94, 98),
+            alpha=0.88,
+            radius=8,
+        )
+        fill_w = int(bar_w * progress) if phase == "collecting" else bar_w
+        if fill_w > 0:
+            self._draw_rounded_rect(
+                frame_bgr,
+                bar_x,
+                bar_y,
+                fill_w,
+                16,
+                8,
+                self.LIVE_BORDER if phase == "saved" else self.WARNING,
+                -1,
+            )
+
+        sample_text = f"Valid knee-angle samples: {status.get('sample_count', 0)}"
+        current_angle = "Current knee: N/A"
+        if squat_state is not None and squat_state.knee_angle is not None:
+            current_angle = f"Current knee: {squat_state.knee_angle:.1f} deg"
+        self._put_text(frame_bgr, sample_text, panel_x + 24, panel_y + 142, 0.46, self.LIVE_TEXT)
+        self._put_text(frame_bgr, current_angle, panel_x + 310, panel_y + 142, 0.46, self.LIVE_TEXT)
+
+        phase_label = {
+            "collecting": "Collecting movement range",
+            "saved": "Calibration saved",
+            "failed": "Calibration needs retry",
+            "reset": "Calibration reset",
+            "error": "Calibration unavailable",
+        }.get(phase, phase.title())
+        phase_color = self.LIVE_BORDER if phase == "saved" else self.WARNING
+        if phase in ("failed", "error"):
+            phase_color = self.ERROR
+        self._put_text(frame_bgr, phase_label, panel_x + 24, panel_y + 176, 0.56, phase_color, 2)
+        self._put_text(
+            frame_bgr,
+            status.get("message", ""),
+            panel_x + 24,
+            panel_y + 204,
+            0.4,
+            self.LIVE_MUTED,
+            max_width=panel_w - 48,
+        )
+
+        values_y = panel_y + 238
+        if profile is not None:
+            values = [
+                ("Standing", profile.standing_knee_angle),
+                ("Lowest", profile.lowest_knee_angle),
+                ("Down", profile.calibrated_down_angle),
+                ("Shallow", profile.calibrated_shallow_angle),
+            ]
+            card_w = (panel_w - 48 - 24) // 4
+            for index, (label, value) in enumerate(values):
+                x = panel_x + 24 + (card_w + 8) * index
+                self._draw_panel(
+                    frame_bgr,
+                    x,
+                    values_y,
+                    card_w,
+                    48,
+                    color=self.LIVE_CARD,
+                    border_color=(78, 94, 98),
+                    alpha=0.9,
+                    radius=10,
+                )
+                self._put_text(frame_bgr, label, x + 10, values_y + 18, 0.32, self.LIVE_MUTED)
+                self._put_text(frame_bgr, f"{value:.1f}", x + 10, values_y + 40, 0.48, self.LIVE_TEXT, 2)
+        else:
+            self._put_text(
+                frame_bgr,
+                "No saved calibration yet. Defaults are used until calibration succeeds.",
+                panel_x + 24,
+                values_y + 28,
+                0.4,
+                self.LIVE_MUTED,
+                max_width=panel_w - 48,
+            )
+
+        self._put_text(
+            frame_bgr,
+            "R reset/retry   |   Esc dashboard",
+            panel_x + 24,
+            panel_y + panel_h - 22,
+            0.38,
+            self.LIVE_MUTED,
+            max_width=panel_w - 48,
         )
 
     def draw_debug(self, frame_bgr, debug_info: dict) -> None:


### PR DESCRIPTION
Closes #46 

What changed:
- Added user calibration mode for squat-depth thresholds.
- Stored calibration values locally.
- Allowed squat analysis to use calibrated thresholds when available.
- Added reset calibration option.
- Preserved default thresholds as fallback.

How to run/test:
python src/app.py

Test steps:
- Open the app.
- Start calibration from the dashboard.
- Perform several squats.
- Confirm calibration values are saved.
- Start a squat session and confirm rep counting still works.
- Reset calibration and confirm defaults are used again.

Evidence:
- System now supports adaptive thresholds as a lightweight alternative to training a custom ML classifier