### PR TITLE
feat: add camera source selection

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import ctypes
 from ctypes import wintypes
 from datetime import datetime
+from functools import lru_cache
 import os
+import subprocess
 import time
 
 import cv2
@@ -21,6 +23,8 @@ from core.user_profile import (
     load_squat_config,
     reset_calibration_profile,
     save_calibration_profile,
+    set_camera_index,
+    switch_camera_index,
     toggle_hide_incomplete_sessions,
     toggle_theme,
 )
@@ -51,8 +55,15 @@ DOWN_KEY = 2621440
 FEEDBACK_HOLD_SECONDS = 2.0
 SW_MAXIMIZE = 3
 STATIC_SCREEN_WAIT_MS = 80
+CAMERA_INDICES = (0, 1, 2)
+FALLBACK_CAMERA_LABELS = {
+    0: "Default / built-in",
+    1: "External USB",
+    2: "Phone / virtual",
+}
 
 _WINDOW_MAXIMIZED = False
+_LAST_CAMERA_WARNING: str | None = None
 
 
 def _sync_app_background(overlay: OverlayRenderer) -> None:
@@ -270,17 +281,124 @@ def _calibration_status(
     }
 
 
-def run_session(overlay: OverlayRenderer) -> bool:
-    """Run one workout session and persist outputs on exit."""
-    cap = cv2.VideoCapture(0)
-    if not cap.isOpened():
-        print("Warning: could not open webcam for session.")
-        return _window_is_open(WINDOW_NAME)
+def _camera_backend() -> int:
+    if os.name == "nt":
+        return cv2.CAP_DSHOW
+    return cv2.CAP_ANY
 
-    # Request 720p capture when supported by the camera.
+
+@lru_cache(maxsize=1)
+def _windows_camera_names() -> tuple[str, ...]:
+    """Best-effort Windows camera names for display; OpenCV still uses indices."""
+    if os.name != "nt":
+        return ()
+
+    command = (
+        "Get-CimInstance Win32_PnPEntity | "
+        "Where-Object { $_.PNPClass -eq 'Camera' -or $_.PNPClass -eq 'Image' } | "
+        "Select-Object -ExpandProperty Name"
+    )
+    try:
+        completed = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", command],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ()
+
+    names = []
+    for line in completed.stdout.splitlines():
+        name = line.strip()
+        if name:
+            names.append(name)
+    return tuple(names)
+
+
+def _camera_options() -> list[dict[str, object]]:
+    detected_names = _windows_camera_names()
+    options = []
+    for index in CAMERA_INDICES:
+        label = (
+            detected_names[index]
+            if index < len(detected_names)
+            else FALLBACK_CAMERA_LABELS[index]
+        )
+        options.append(
+            {
+                "index": index,
+                "label": label,
+                "detected": index < len(detected_names),
+            }
+        )
+    return options
+
+
+def _configure_camera(cap: cv2.VideoCapture) -> None:
+    # These are requests only; unsupported cameras keep their own defaults.
     cap.set(cv2.CAP_PROP_FRAME_WIDTH, FRAME_WIDTH)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT)
     cap.set(cv2.CAP_PROP_FPS, 30)
+
+
+def _camera_has_frame(cap: cv2.VideoCapture) -> bool:
+    for _ in range(5):
+        ok, _frame = cap.read()
+        if ok:
+            return True
+        time.sleep(0.03)
+    return False
+
+
+def _open_camera(camera_index: int, context: str) -> tuple[cv2.VideoCapture | None, int]:
+    """Open the selected camera index, falling back to index 0 when needed."""
+    global _LAST_CAMERA_WARNING
+
+    requested_index = camera_index if 0 <= camera_index <= 2 else 0
+    indices = [requested_index]
+    if requested_index != 0:
+        indices.append(0)
+
+    for index in indices:
+        cap = cv2.VideoCapture(index, _camera_backend())
+        if cap.isOpened():
+            _configure_camera(cap)
+            if not _camera_has_frame(cap):
+                cap.release()
+                print(f"Warning: camera {index} opened but produced no frames for {context}.")
+                continue
+
+            if index != requested_index:
+                warning = (
+                    f"Warning: camera {requested_index} could not be opened for "
+                    f"{context}; using camera 0 instead."
+                )
+                print(warning)
+                _LAST_CAMERA_WARNING = warning
+                set_camera_index(load_app_settings(), 0)
+            else:
+                _LAST_CAMERA_WARNING = None
+            return cap, index
+
+        cap.release()
+        print(f"Warning: camera {index} could not be opened for {context}.")
+
+    _LAST_CAMERA_WARNING = (
+        f"Warning: camera {requested_index} could not be opened for {context}, "
+        "and fallback camera 0 also failed."
+    )
+    print(_LAST_CAMERA_WARNING)
+    return None, requested_index
+
+
+def run_session(overlay: OverlayRenderer) -> bool:
+    """Run one workout session and persist outputs on exit."""
+    settings = load_app_settings()
+    cap, _active_camera_index = _open_camera(settings.camera_index, "session")
+    if cap is None:
+        return _window_is_open(WINDOW_NAME)
 
     detector = PoseDetector()
     calibration_profile = load_calibration_profile()
@@ -510,14 +628,14 @@ def run_analytics(overlay: OverlayRenderer) -> bool:
 
 def run_calibration(overlay: OverlayRenderer) -> bool:
     """Collect a short calibration set and save user-specific squat thresholds."""
-    cap = cv2.VideoCapture(0)
+    settings = load_app_settings()
+    cap, _active_camera_index = _open_camera(settings.camera_index, "calibration")
     profile = load_calibration_profile()
 
-    if not cap.isOpened():
-        cap.release()
+    if cap is None:
         status = _calibration_status(
             phase="error",
-            message="Could not open webcam for calibration.",
+            message="Could not open selected camera or fallback camera 0.",
             profile=profile,
         )
         while True:
@@ -541,10 +659,6 @@ def run_calibration(overlay: OverlayRenderer) -> bool:
                     message="Calibration reset. Defaults will be used.",
                     profile=profile,
                 )
-
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, FRAME_WIDTH)
-    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT)
-    cap.set(cv2.CAP_PROP_FPS, 30)
 
     detector = PoseDetector()
     analyzer = SquatStateAnalyzer()
@@ -636,7 +750,12 @@ def run_settings(overlay: OverlayRenderer) -> bool:
             return False
 
         frame = _blank_screen()
-        overlay.draw_settings(frame, settings, load_calibration_profile())
+        overlay.draw_settings(
+            frame,
+            settings,
+            load_calibration_profile(),
+            _camera_options(),
+        )
         _show_frame(WINDOW_NAME, frame)
 
         key = _wait_for_key_or_close(STATIC_SCREEN_WAIT_MS)
@@ -652,11 +771,16 @@ def run_settings(overlay: OverlayRenderer) -> bool:
             _sync_app_background(overlay)
         elif key in (ord("h"), ord("H")):
             settings = toggle_hide_incomplete_sessions(settings)
+        elif key in (ord("k"), ord("K")):
+            _windows_camera_names.cache_clear()
+            settings = switch_camera_index(settings)
         elif key in (ord("r"), ord("R")):
             reset_calibration_profile()
 
 
 def main() -> None:
+    global _LAST_CAMERA_WARNING
+
     settings = load_app_settings()
     overlay = OverlayRenderer(settings.theme)
     _sync_app_background(overlay)
@@ -669,8 +793,15 @@ def main() -> None:
                 break
 
             if state == STATE_DASHBOARD:
+                settings = load_app_settings()
                 frame = _blank_screen()
-                overlay.draw_dashboard(frame, load_calibration_profile())
+                overlay.draw_dashboard(
+                    frame,
+                    load_calibration_profile(),
+                    settings,
+                    _LAST_CAMERA_WARNING,
+                    _camera_options(),
+                )
                 _show_frame(WINDOW_NAME, frame)
                 key = _wait_for_key_or_close(STATIC_SCREEN_WAIT_MS)
 
@@ -688,6 +819,10 @@ def main() -> None:
                     state = STATE_ANALYTICS
                 elif key in (ord("g"), ord("G")):
                     state = STATE_SETTINGS
+                elif key in (ord("k"), ord("K")):
+                    _windows_camera_names.cache_clear()
+                    settings = switch_camera_index(settings)
+                    _LAST_CAMERA_WARNING = None
                 elif key == 27:
                     break
             elif state == STATE_SESSION:

--- a/src/core/user_profile.py
+++ b/src/core/user_profile.py
@@ -41,6 +41,7 @@ class CalibrationProfile:
 class AppSettings:
     theme: str = "light"
     hide_incomplete_sessions: bool = False
+    camera_index: int = 0
 
 
 def load_calibration_profile() -> CalibrationProfile | None:
@@ -91,6 +92,7 @@ def load_app_settings() -> AppSettings:
         return AppSettings(
             theme=theme,
             hide_incomplete_sessions=bool(data.get("hide_incomplete_sessions", False)),
+            camera_index=_normalize_camera_index(data.get("camera_index", 0)),
         )
     except (OSError, TypeError, ValueError, json.JSONDecodeError):
         return AppSettings()
@@ -101,6 +103,7 @@ def save_app_settings(settings: AppSettings) -> AppSettings:
     normalized = AppSettings(
         theme=settings.theme if settings.theme in ("light", "dark") else "light",
         hide_incomplete_sessions=bool(settings.hide_incomplete_sessions),
+        camera_index=_normalize_camera_index(settings.camera_index),
     )
     SETTINGS_FILE.write_text(
         json.dumps(asdict(normalized), indent=2),
@@ -120,6 +123,17 @@ def toggle_hide_incomplete_sessions(settings: AppSettings) -> AppSettings:
             settings,
             hide_incomplete_sessions=not settings.hide_incomplete_sessions,
         )
+    )
+
+
+def switch_camera_index(settings: AppSettings) -> AppSettings:
+    next_index = (_normalize_camera_index(settings.camera_index) + 1) % 3
+    return save_app_settings(replace(settings, camera_index=next_index))
+
+
+def set_camera_index(settings: AppSettings, camera_index: int) -> AppSettings:
+    return save_app_settings(
+        replace(settings, camera_index=_normalize_camera_index(camera_index))
     )
 
 
@@ -197,3 +211,11 @@ def _mean(values: list[float]) -> float:
 
 def _clamp(value: float, minimum: float, maximum: float) -> float:
     return max(minimum, min(maximum, value))
+
+
+def _normalize_camera_index(value) -> int:
+    try:
+        camera_index = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return camera_index if 0 <= camera_index <= 2 else 0

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -121,7 +121,14 @@ class OverlayRenderer:
             calibration_profile,
         )
 
-    def draw_dashboard(self, frame_bgr, calibration_profile=None) -> None:
+    def draw_dashboard(
+        self,
+        frame_bgr,
+        calibration_profile=None,
+        settings=None,
+        notice_message: str | None = None,
+        camera_options=None,
+    ) -> None:
         self._fill_background(frame_bgr)
         frame_h, frame_w = frame_bgr.shape[:2]
 
@@ -179,9 +186,15 @@ class OverlayRenderer:
             max_width=shell_w - 124,
         )
 
-        insight_w = 250
+        camera_index = getattr(settings, "camera_index", 0)
+        camera_label = self._format_camera_display(
+            camera_index,
+            camera_options,
+            include_index=True,
+        )
+        insight_w = 210
         insight_gap = 14
-        insight_x = shell_x + shell_w - (insight_w * 2) - insight_gap - 48
+        insight_x = shell_x + shell_w - (insight_w * 3) - (insight_gap * 2) - 48
         insight_y = shell_y + 58
         self._draw_info_card(
             frame_bgr, insight_x, insight_y, insight_w, "Scope", "Squat analysis only"
@@ -189,6 +202,14 @@ class OverlayRenderer:
         self._draw_info_card(
             frame_bgr,
             insight_x + insight_w + insight_gap,
+            insight_y,
+            insight_w,
+            "Camera",
+            camera_label,
+        )
+        self._draw_info_card(
+            frame_bgr,
+            insight_x + ((insight_w + insight_gap) * 2),
             insight_y,
             insight_w,
             "Calibration",
@@ -223,9 +244,21 @@ class OverlayRenderer:
                 subtitle,
             )
 
+        if notice_message:
+            self._put_text(
+                frame_bgr,
+                notice_message,
+                shell_x + 62,
+                shell_y + shell_h - 58,
+                scale=0.42,
+                color=self.WARNING,
+                thickness=1,
+                max_width=shell_w - 124,
+            )
+
         self._put_text(
             frame_bgr,
-            "Keyboard controlled desktop prototype. Use Esc to return from any screen.",
+            "Keyboard controlled desktop prototype. K switches camera source. Esc returns from any screen.",
             shell_x + 62,
             shell_y + shell_h - 34,
             scale=0.47,
@@ -780,7 +813,13 @@ class OverlayRenderer:
             max_width=panel_w - 48,
         )
 
-    def draw_settings(self, frame_bgr, settings, calibration_profile=None) -> None:
+    def draw_settings(
+        self,
+        frame_bgr,
+        settings,
+        calibration_profile=None,
+        camera_options=None,
+    ) -> None:
         self._fill_background(frame_bgr)
         frame_h, frame_w = frame_bgr.shape[:2]
         margin = 34
@@ -789,7 +828,7 @@ class OverlayRenderer:
             frame_bgr,
             margin,
             "Settings",
-            "T toggle theme  |  H hide/show incomplete  |  R reset calibration  |  Esc dashboard",
+            "T toggle theme  |  K switch camera  |  H hide/show incomplete  |  R reset calibration  |  Esc dashboard",
         )
 
         panel_x = margin
@@ -830,8 +869,14 @@ class OverlayRenderer:
 
         card_gap = 16
         card_y = panel_y + 112
-        card_w = (panel_w - 56 - (card_gap * 2)) // 3
+        card_w = (panel_w - 56 - (card_gap * 3)) // 4
         theme_value = getattr(settings, "theme", "light").title()
+        camera_index = getattr(settings, "camera_index", 0)
+        camera_value = self._format_camera_display(
+            camera_index,
+            camera_options,
+            include_index=True,
+        )
         browser_value = (
             "Hiding incomplete"
             if getattr(settings, "hide_incomplete_sessions", False)
@@ -844,8 +889,14 @@ class OverlayRenderer:
         )
         cards = [
             ("Theme", theme_value, "Press T to switch light/dark", self.PRIMARY),
+            ("Camera", camera_value, "Press K to cycle sources", self.INFO),
             ("Session Browser", browser_value, "Press H to toggle visibility", self.TEXT),
-            ("Calibration", calibration_value, "Press R to reset calibration", self.WARNING if calibration_profile else self.MUTED),
+            (
+                "Calibration",
+                calibration_value,
+                "Press R to reset calibration",
+                self.WARNING if calibration_profile else self.MUTED,
+            ),
         ]
 
         for index, (label, value, helper, value_color) in enumerate(cards):
@@ -882,7 +933,18 @@ class OverlayRenderer:
                 max_width=card_w - 36,
             )
 
-        note_y = card_y + 158
+        camera_hint_y = card_y + 140
+        self._put_text(
+            frame_bgr,
+            self._format_camera_options_line(camera_options),
+            panel_x + 28,
+            camera_hint_y,
+            0.4,
+            self.MUTED,
+            max_width=panel_w - 56,
+        )
+
+        note_y = card_y + 174
         self._put_text(
             frame_bgr,
             "Safety note",
@@ -2073,6 +2135,41 @@ class OverlayRenderer:
         if not value:
             return "none"
         return value.replace("_", " ")
+
+    @staticmethod
+    def _camera_fallback_label(index: int) -> str:
+        labels = {
+            0: "Default / built-in",
+            1: "External USB",
+            2: "Phone / virtual",
+        }
+        return labels.get(index, f"Camera {index}")
+
+    def _format_camera_display(
+        self,
+        camera_index: int,
+        camera_options=None,
+        *,
+        include_index: bool = False,
+    ) -> str:
+        label = self._camera_fallback_label(camera_index)
+        if camera_options:
+            for option in camera_options:
+                if int(option.get("index", -1)) == camera_index:
+                    label = str(option.get("label") or label)
+                    break
+        return f"{camera_index} - {label}" if include_index else label
+
+    def _format_camera_options_line(self, camera_options=None) -> str:
+        if not camera_options:
+            return "Camera labels: 0 Default / built-in | 1 External USB | 2 Phone / virtual"
+
+        parts = []
+        for option in camera_options:
+            index = int(option.get("index", 0))
+            label = str(option.get("label") or self._camera_fallback_label(index))
+            parts.append(f"{index} {label}")
+        return "Camera sources: " + "  |  ".join(parts)
 
     def _change_color(
         self, value: int | float | None, *, positive_is_good: bool


### PR DESCRIPTION
Closes #50 

What changed:
- Added selectable OpenCV camera source support.
- Allows use of built-in webcams, external webcams, or phone cameras exposed as webcam devices.
- Added fallback handling when the selected camera cannot be opened.
- Displayed the current camera source in the dashboard.

How to run/test:
python src/app.py

Test steps:
- Launch the app and confirm camera index 0 is selected by default.
- Switch camera source from the dashboard/settings screen.
- Start a session and confirm the selected camera is used.
- Test invalid/unavailable camera index and confirm the app does not crash.
- Confirm recording, analytics, and session saving still work.

Evidence:
- GymGuardian can now use external camera sources through OpenCV camera indexing.