### PR TITLE
feat: add analytics trends dashboard and HTML export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ assets/models/*.task
 
 sessions/
 user_data/
+exports/

--- a/src/app.py
+++ b/src/app.py
@@ -35,6 +35,7 @@ from session.browser import (
     open_session_folder,
     open_session_video,
 )
+from session.analytics_export import export_analytics_report
 from session.recorder import SessionRecorder
 from session.summary import SessionSummary
 from ui.overlay import OverlayRenderer
@@ -113,13 +114,6 @@ def _wait_for_key_or_close(delay_ms: int) -> int | None:
 
 
 def _blank_screen() -> np.ndarray:
-    window_size = _get_window_client_size(WINDOW_NAME)
-    if window_size is not None:
-        window_w, window_h = window_size
-        canvas = np.empty((window_h, window_w, 3), dtype=np.uint8)
-        canvas[:] = APP_BG
-        return canvas
-
     canvas = np.empty((FRAME_HEIGHT, FRAME_WIDTH, 3), dtype=np.uint8)
     canvas[:] = APP_BG
     return canvas
@@ -624,6 +618,16 @@ def run_analytics(overlay: OverlayRenderer) -> bool:
         if key in (ord("r"), ord("R")):
             snapshot = load_analytics_snapshot(SESSIONS_DIR)
             calibration_profile = load_calibration_profile()
+        elif key in (ord("e"), ord("E")):
+            report_path = export_analytics_report(
+                snapshot,
+                calibration_profile=calibration_profile,
+            )
+            print(f"Analytics report exported: {report_path}")
+            try:
+                os.startfile(str(report_path))
+            except (AttributeError, OSError) as exc:
+                print(f"Warning: could not open analytics report: {exc}")
 
 
 def run_calibration(overlay: OverlayRenderer) -> bool:

--- a/src/session/analytics_export.py
+++ b/src/session/analytics_export.py
@@ -1,0 +1,325 @@
+"""HTML export helpers for GymGuardian analytics evidence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from html import escape
+from pathlib import Path
+
+from core.paths import PROJECT_ROOT
+from session.browser import AnalyticsSnapshot
+
+
+EXPORTS_DIR = PROJECT_ROOT / "exports"
+DEFAULT_ANALYTICS_REPORT = EXPORTS_DIR / "analytics_report.html"
+
+
+def export_analytics_report(
+    snapshot: AnalyticsSnapshot,
+    output_path: Path = DEFAULT_ANALYTICS_REPORT,
+    calibration_profile=None,
+) -> Path:
+    """Write a polished project-level analytics report and return its path."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        _build_html(snapshot, calibration_profile),
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def _build_html(snapshot: AnalyticsSnapshot, calibration_profile=None) -> str:
+    generated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    calibration_status = "Calibrated" if calibration_profile else "Default thresholds"
+    latest_session = _format_timestamp(snapshot.latest_timestamp)
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GymGuardian Analytics Report</title>
+  <style>
+    :root {{
+      --bg: #eef5ef;
+      --panel: #ffffff;
+      --panel-soft: #f5faf6;
+      --ink: #20332a;
+      --muted: #617268;
+      --line: #bfd0c2;
+      --green: #2f7d52;
+      --green-soft: #dff1e4;
+      --blue: #2f6f9f;
+      --amber: #ad7624;
+      --red: #b94d45;
+      --shadow: 0 18px 45px rgba(35, 61, 42, 0.12);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      font-family: "Segoe UI", Arial, sans-serif;
+      background:
+        radial-gradient(circle at top right, rgba(70, 132, 84, 0.16), transparent 28rem),
+        linear-gradient(135deg, #f8fbf8 0%, var(--bg) 100%);
+      color: var(--ink);
+    }}
+    main {{
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 40px 28px 56px;
+    }}
+    header {{
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      align-items: flex-start;
+      margin-bottom: 26px;
+    }}
+    h1 {{
+      margin: 0 0 8px;
+      font-size: 42px;
+      letter-spacing: -0.04em;
+    }}
+    h2 {{
+      margin: 0 0 16px;
+      font-size: 22px;
+      letter-spacing: -0.02em;
+    }}
+    p {{ margin: 0; color: var(--muted); line-height: 1.55; }}
+    .badge {{
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 8px 14px;
+      background: var(--green-soft);
+      color: var(--green);
+      font-weight: 700;
+      white-space: nowrap;
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 16px;
+      margin: 24px 0;
+    }}
+    .card {{
+      background: rgba(255, 255, 255, 0.88);
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      padding: 22px;
+      box-shadow: var(--shadow);
+    }}
+    .metric-label {{
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }}
+    .metric-value {{
+      margin-top: 10px;
+      font-size: 30px;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+    }}
+    .section {{
+      margin-top: 18px;
+      background: rgba(255, 255, 255, 0.88);
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      padding: 24px;
+      box-shadow: var(--shadow);
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border-radius: 16px;
+    }}
+    th, td {{
+      text-align: left;
+      padding: 13px 12px;
+      border-bottom: 1px solid #d8e4da;
+      font-size: 14px;
+    }}
+    th {{
+      color: var(--muted);
+      background: var(--panel-soft);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 12px;
+    }}
+    tr:last-child td {{ border-bottom: 0; }}
+    .split {{
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 18px;
+    }}
+    .issue-row {{
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      padding: 12px 0;
+      border-bottom: 1px solid #d8e4da;
+    }}
+    .issue-row:last-child {{ border-bottom: 0; }}
+    .note {{
+      margin-top: 20px;
+      padding: 16px 18px;
+      border-left: 5px solid var(--green);
+      background: #edf7ef;
+      border-radius: 14px;
+    }}
+    .good {{ color: var(--green); }}
+    .warn {{ color: var(--amber); }}
+    .bad {{ color: var(--red); }}
+    @media (max-width: 860px) {{
+      header, .split {{ grid-template-columns: 1fr; display: grid; }}
+      .grid {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>GymGuardian Analytics Report</h1>
+        <p>Project-level squat coaching analytics generated from local session summaries.</p>
+      </div>
+      <div class="badge">{escape(calibration_status)}</div>
+    </header>
+
+    <section class="grid">
+      {_metric_card("Generated", generated_at)}
+      {_metric_card("Total sessions", snapshot.total_sessions)}
+      {_metric_card("Meaningful sessions", snapshot.meaningful_session_count)}
+      {_metric_card("Latest session", latest_session)}
+      {_metric_card("Latest reps", _display(snapshot.latest_rep_count))}
+      {_metric_card("Latest bad reps", _display(snapshot.latest_bad_rep_count), "bad" if (snapshot.latest_bad_rep_count or 0) > 0 else "")}
+      {_metric_card("Bad rep rate", _format_percentage(snapshot.latest_bad_rep_percentage), "warn" if (snapshot.latest_bad_rep_percentage or 0) > 0 else "")}
+      {_metric_card("Average FPS", _format_fps(snapshot.latest_avg_fps))}
+    </section>
+
+    <section class="section">
+      <h2>Recent Meaningful Session Trends</h2>
+      {_trend_table(snapshot)}
+    </section>
+
+    <section class="section split">
+      <div>
+        <h2>Issue Breakdown</h2>
+        {_issue_breakdown(snapshot)}
+      </div>
+      <div>
+        <h2>Recommendation</h2>
+        <p><strong>Main concern:</strong> {escape(snapshot.main_concern or "N/A")}</p>
+        <p><strong>Suggested improvement:</strong> {escape(snapshot.suggested_improvement or "N/A")}</p>
+        <p><strong>Focus area:</strong> {escape(snapshot.focus_area or "N/A")}</p>
+        <div class="note">
+          Incomplete sessions are kept on disk but ignored for meaningful-session analytics.
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def _metric_card(label: str, value, css_class: str = "") -> str:
+    return (
+        '<article class="card">'
+        f'<div class="metric-label">{escape(str(label))}</div>'
+        f'<div class="metric-value {escape(css_class)}">{escape(str(value))}</div>'
+        "</article>"
+    )
+
+
+def _trend_table(snapshot: AnalyticsSnapshot) -> str:
+    if not snapshot.trend_sessions:
+        return "<p>No meaningful session data available yet.</p>"
+
+    rows = []
+    for item in snapshot.trend_sessions:
+        rows.append(
+            "<tr>"
+            f"<td>{escape(_format_timestamp(item.folder_name))}</td>"
+            f"<td>{item.rep_count}</td>"
+            f"<td>{item.bad_rep_count}</td>"
+            f"<td>{escape(_format_percentage(item.bad_rep_percentage))}</td>"
+            f"<td>{escape(_format_angle(item.avg_knee_angle))}</td>"
+            f"<td>{escape(_format_angle(item.avg_ankle_angle))}</td>"
+            f"<td>{escape(_format_angle(item.avg_torso_angle))}</td>"
+            f"<td>{escape(_format_fps(item.avg_fps))}</td>"
+            f"<td>{escape(_format_issue(item.most_common_issue))}</td>"
+            "</tr>"
+        )
+
+    return (
+        "<table>"
+        "<thead><tr>"
+        "<th>Session</th><th>Reps</th><th>Bad</th><th>Bad rate</th>"
+        "<th>Avg knee</th><th>Avg ankle</th><th>Torso</th><th>FPS</th><th>Issue</th>"
+        "</tr></thead>"
+        "<tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+
+
+def _issue_breakdown(snapshot: AnalyticsSnapshot) -> str:
+    if not snapshot.issue_totals:
+        return "<p>No repeated form issue has been recorded across meaningful sessions.</p>"
+
+    rows = []
+    for issue, count in list(snapshot.issue_totals.items())[:6]:
+        rows.append(
+            '<div class="issue-row">'
+            f"<span>{escape(_format_issue(issue))}</span>"
+            f"<strong>{count}</strong>"
+            "</div>"
+        )
+    return "".join(rows)
+
+
+def _display(value) -> str:
+    if value is None:
+        return "N/A"
+    return str(value)
+
+
+def _format_percentage(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.1f}%"
+
+
+def _format_angle(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.1f} deg"
+
+
+def _format_fps(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.1f}"
+
+
+def _format_issue(value: str | None) -> str:
+    if not value:
+        return "none"
+    return value.replace("_", " ")
+
+
+def _format_timestamp(value: str | None) -> str:
+    if not value:
+        return "N/A"
+    if len(value) == 15 and "_" in value:
+        date_part, time_part = value.split("_", maxsplit=1)
+        if len(date_part) == 8 and len(time_part) == 6:
+            return (
+                f"{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
+                f"{time_part[0:2]}:{time_part[2:4]}:{time_part[4:6]}"
+            )
+    return value

--- a/src/session/browser.py
+++ b/src/session/browser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import os
 from pathlib import Path
@@ -38,15 +38,34 @@ class AnalyticsSnapshot:
     latest_min_knee_angle: Optional[float] = None
     latest_avg_ankle_angle: Optional[float] = None
     latest_avg_torso_angle: Optional[float] = None
+    latest_avg_fps: Optional[float] = None
     latest_most_common_issue: Optional[str] = None
     previous_timestamp: Optional[str] = None
     previous_rep_count: Optional[int] = None
     rep_count_change: Optional[int] = None
     bad_rep_percentage_change: Optional[float] = None
     avg_knee_angle_change: Optional[float] = None
+    avg_fps_overall: Optional[float] = None
+    trend_sessions: tuple["AnalyticsTrendItem", ...] = field(default_factory=tuple)
+    issue_totals: dict[str, int] = field(default_factory=dict)
     main_concern: Optional[str] = None
     suggested_improvement: Optional[str] = None
     focus_area: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AnalyticsTrendItem:
+    """Compact session row used for analytics trend display and export."""
+
+    folder_name: str
+    rep_count: int
+    bad_rep_count: int
+    bad_rep_percentage: Optional[float]
+    avg_knee_angle: Optional[float]
+    avg_ankle_angle: Optional[float]
+    avg_torso_angle: Optional[float]
+    avg_fps: Optional[float]
+    most_common_issue: Optional[str]
 
 
 @dataclass(frozen=True)
@@ -61,6 +80,8 @@ class AnalyticsSessionItem:
     min_knee_angle: Optional[float]
     avg_ankle_angle: Optional[float]
     avg_torso_angle: Optional[float]
+    avg_fps: Optional[float]
+    issue_counts: dict[str, int]
     most_common_issue: Optional[str]
 
 
@@ -146,6 +167,13 @@ def load_analytics_snapshot(sessions_dir: Path) -> AnalyticsSnapshot:
     main_concern, suggested_improvement, focus_area = build_recommendation(
         latest.most_common_issue
     )
+    trend_sessions = tuple(
+        _build_trend_item(session) for session in meaningful_sessions[:15]
+    )
+    issue_totals = _aggregate_issue_counts(meaningful_sessions)
+    avg_fps_overall = _average_optional(
+        [session.avg_fps for session in meaningful_sessions]
+    )
 
     return AnalyticsSnapshot(
         total_sessions=len(recent_sessions),
@@ -158,12 +186,16 @@ def load_analytics_snapshot(sessions_dir: Path) -> AnalyticsSnapshot:
         latest_min_knee_angle=latest.min_knee_angle,
         latest_avg_ankle_angle=latest.avg_ankle_angle,
         latest_avg_torso_angle=latest.avg_torso_angle,
+        latest_avg_fps=latest.avg_fps,
         latest_most_common_issue=latest.most_common_issue,
         previous_timestamp=previous.folder_name if previous else None,
         previous_rep_count=previous.rep_count if previous else None,
         rep_count_change=rep_count_change,
         bad_rep_percentage_change=bad_rep_percentage_change,
         avg_knee_angle_change=avg_knee_angle_change,
+        avg_fps_overall=avg_fps_overall,
+        trend_sessions=trend_sessions,
+        issue_totals=issue_totals,
         main_concern=main_concern,
         suggested_improvement=suggested_improvement,
         focus_area=focus_area,
@@ -228,6 +260,8 @@ def _load_analytics_sessions(
                 min_knee_angle=_safe_float(data.get("min_knee_angle")),
                 avg_ankle_angle=_safe_float(data.get("avg_ankle_angle")),
                 avg_torso_angle=_safe_float(data.get("avg_torso_angle")),
+                avg_fps=_safe_float(data.get("avg_fps")),
+                issue_counts=_safe_issue_counts(data.get("issue_counts")),
                 most_common_issue=most_common_issue,
             )
         )
@@ -280,3 +314,56 @@ def _safe_float(value) -> Optional[float]:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _safe_issue_counts(value) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+
+    issue_counts: dict[str, int] = {}
+    for issue, count in value.items():
+        issue_name = str(issue).strip()
+        if not issue_name:
+            continue
+        safe_count = _safe_int(count)
+        if safe_count is None or safe_count <= 0:
+            continue
+        issue_counts[issue_name] = safe_count
+    return issue_counts
+
+
+def _aggregate_issue_counts(
+    sessions: list[AnalyticsSessionItem],
+) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for session in sessions:
+        for issue, count in session.issue_counts.items():
+            totals[issue] = totals.get(issue, 0) + count
+
+    return dict(
+        sorted(
+            totals.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    )
+
+
+def _build_trend_item(session: AnalyticsSessionItem) -> AnalyticsTrendItem:
+    return AnalyticsTrendItem(
+        folder_name=session.folder_name,
+        rep_count=session.rep_count,
+        bad_rep_count=session.bad_rep_count,
+        bad_rep_percentage=bad_rep_percentage(session.rep_count, session.bad_rep_count),
+        avg_knee_angle=session.avg_knee_angle,
+        avg_ankle_angle=session.avg_ankle_angle,
+        avg_torso_angle=session.avg_torso_angle,
+        avg_fps=session.avg_fps,
+        most_common_issue=session.most_common_issue,
+    )
+
+
+def _average_optional(values: list[Optional[float]]) -> Optional[float]:
+    valid_values = [value for value in values if value is not None]
+    if not valid_values:
+        return None
+    return round(sum(valid_values) / len(valid_values), 2)

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -170,10 +170,10 @@ class OverlayRenderer:
             "GymGuardian",
             shell_x + 58,
             shell_y + 150,
-            scale=1.7,
+            scale=1.48,
             color=self.PRIMARY,
             thickness=2,
-            max_width=shell_w - 116,
+            max_width=470,
         )
         self._put_text(
             frame_bgr,
@@ -192,7 +192,7 @@ class OverlayRenderer:
             camera_options,
             include_index=True,
         )
-        insight_w = 210
+        insight_w = 170
         insight_gap = 14
         insight_x = shell_x + shell_w - (insight_w * 3) - (insight_gap * 2) - 48
         insight_y = shell_y + 58
@@ -500,13 +500,13 @@ class OverlayRenderer:
             frame_bgr,
             margin,
             "Analytics Dashboard",
-            "R refresh  |  Esc dashboard",
+            "R refresh  |  E export report  |  Esc dashboard",
         )
 
         summary_x = margin
         summary_y = 118
         summary_w = frame_w - (margin * 2)
-        summary_h = 338
+        summary_h = 310
         lower_y = summary_y + summary_h + 18
         lower_h = frame_h - lower_y - margin
 
@@ -567,7 +567,7 @@ class OverlayRenderer:
         cards_w = summary_w - 44
         gap = 12
         card_w = (cards_w - (gap * 3)) // 4
-        card_h = 62
+        card_h = 64
         row_one_y = summary_y + 90
         row_two_y = row_one_y + card_h + gap
         row_three_y = row_two_y + card_h + gap
@@ -615,7 +615,8 @@ class OverlayRenderer:
                 label,
                 value,
                 color,
-                value_scale=0.68,
+                label_scale=0.42,
+                value_scale=0.58,
             )
 
         self._draw_metric_tile(
@@ -627,40 +628,65 @@ class OverlayRenderer:
             "Avg Torso Lean",
             self._format_angle(snapshot.latest_avg_torso_angle),
             self.TEXT,
-            value_scale=0.56,
+            label_scale=0.4,
+            value_scale=0.48,
         )
         self._draw_metric_tile(
             frame_bgr,
             cards_x + card_w + gap,
             row_three_y,
-            (card_w * 3) + (gap * 2),
+            card_w,
+            54,
+            "Avg FPS",
+            self._format_fps(snapshot.latest_avg_fps),
+            self.INFO if snapshot.latest_avg_fps is not None else self.TEXT,
+            label_scale=0.4,
+            value_scale=0.48,
+        )
+        self._draw_metric_tile(
+            frame_bgr,
+            cards_x + ((card_w + gap) * 2),
+            row_three_y,
+            (card_w * 2) + gap,
             54,
             "Most Common Issue",
             self._format_issue(snapshot.latest_most_common_issue),
             self.PRIMARY if not snapshot.latest_most_common_issue else self.WARNING,
-            value_scale=0.58,
+            label_scale=0.4,
+            value_scale=0.5,
         )
 
         panel_gap = 18
-        progress_x = margin
-        progress_w = (frame_w - (margin * 2) - panel_gap) // 2
-        report_x = progress_x + progress_w + panel_gap
-        report_w = frame_w - report_x - margin
+        trend_x = margin
+        trend_w = int((frame_w - (margin * 2) - panel_gap) * 0.58)
+        side_x = trend_x + trend_w + panel_gap
+        side_w = frame_w - side_x - margin
+        side_gap = 14
+        progress_h = max(118, (lower_h - side_gap) // 2)
+        report_h = lower_h - progress_h - side_gap
 
+        self._draw_trends_panel(
+            frame_bgr,
+            trend_x,
+            lower_y,
+            trend_w,
+            lower_h,
+            snapshot,
+        )
         self._draw_progress_panel(
             frame_bgr,
-            progress_x,
+            side_x,
             lower_y,
-            progress_w,
-            lower_h,
+            side_w,
+            progress_h,
             snapshot,
         )
         self._draw_session_report_panel(
             frame_bgr,
-            report_x,
-            lower_y,
-            report_w,
-            lower_h,
+            side_x,
+            lower_y + progress_h + side_gap,
+            side_w,
+            report_h,
             snapshot,
         )
 
@@ -1041,6 +1067,206 @@ class OverlayRenderer:
             )
             y += line_height
 
+    def _draw_trends_panel(self, frame_bgr, x, y, width, height, snapshot) -> None:
+        self._draw_panel(
+            frame_bgr,
+            x,
+            y,
+            width,
+            height,
+            color=self.PANEL,
+            border_color=self.BORDER,
+            alpha=0.95,
+        )
+        self._put_text(
+            frame_bgr,
+            "Recent Trends",
+            x + 24,
+            y + 34,
+            scale=0.66,
+            color=self.TEXT,
+            thickness=1,
+            max_width=width - 48,
+        )
+        trend_sessions = list(getattr(snapshot, "trend_sessions", ()))
+        if not trend_sessions:
+            self._put_text(
+                frame_bgr,
+                "Last 15 meaningful sessions",
+                x + 24,
+                y + 60,
+                scale=0.42,
+                color=self.MUTED,
+                max_width=width - 48,
+            )
+            self._put_text(
+                frame_bgr,
+                "No trend data available yet.",
+                x + 24,
+                y + 100,
+                scale=0.52,
+                color=self.MUTED,
+                max_width=width - 48,
+            )
+            return
+
+        visible_sessions = trend_sessions[:15]
+        self._put_text(
+            frame_bgr,
+            f"Last 15 meaningful sessions - showing {len(visible_sessions)}",
+            x + 24,
+            y + 60,
+            scale=0.46,
+            color=self.MUTED,
+            max_width=width - 48,
+        )
+
+        if len(visible_sessions) > 7:
+            rows_per_col = 8
+            row_h = 19
+            row_gap = 1
+            col_gap = 14
+            col_w = (width - 48 - col_gap) // 2
+            start_y = y + 80
+
+            for index, item in enumerate(visible_sessions):
+                col = index // rows_per_col
+                row = index % rows_per_col
+                row_x = x + 24 + (col * (col_w + col_gap))
+                row_y = start_y + (row * (row_h + row_gap))
+                row_color = self.PANEL_STRONG if index == 0 else self.PANEL_ALT
+                self._draw_panel(
+                    frame_bgr,
+                    row_x,
+                    row_y - 15,
+                    col_w,
+                    row_h,
+                    color=row_color,
+                    border_color=self.BORDER_ACTIVE if index == 0 else self.BORDER,
+                    alpha=0.9,
+                    radius=8,
+                )
+                stats = (
+                    f"R{item.rep_count} "
+                    f"B{self._format_compact_percentage(item.bad_rep_percentage)} "
+                    f"K{self._format_compact_angle(item.avg_knee_angle)}"
+                )
+                self._put_text(
+                    frame_bgr,
+                    self._format_short_session_timestamp(item.folder_name),
+                    row_x + 8,
+                    row_y,
+                    0.34,
+                    self.TEXT if index == 0 else self.MUTED,
+                    max_width=82,
+                )
+                self._put_text(
+                    frame_bgr,
+                    stats,
+                    row_x + 98,
+                    row_y,
+                    0.34,
+                    self.TEXT,
+                    max_width=112,
+                )
+                self._put_text(
+                    frame_bgr,
+                    self._format_issue(item.most_common_issue),
+                    row_x + 218,
+                    row_y,
+                    0.34,
+                    self.WARNING if item.most_common_issue else self.PRIMARY,
+                    max_width=col_w - 226,
+                )
+            return
+
+        header_y = y + 78
+        row_h = 18
+        row_gap = 3
+        session_x = x + 24
+        reps_x = x + max(220, width - 420)
+        bad_x = reps_x + 70
+        knee_x = bad_x + 92
+        issue_x = knee_x + 108
+
+        self._put_text(frame_bgr, "Session", session_x, header_y, 0.36, self.MUTED)
+        self._put_text(frame_bgr, "Reps", reps_x, header_y, 0.36, self.MUTED)
+        self._put_text(frame_bgr, "Bad %", bad_x, header_y, 0.36, self.MUTED)
+        self._put_text(frame_bgr, "Avg Knee", knee_x, header_y, 0.36, self.MUTED)
+        self._put_text(frame_bgr, "Issue", issue_x, header_y, 0.36, self.MUTED)
+        cv2.line(frame_bgr, (x + 22, y + 88), (x + width - 22, y + 88), self.BORDER, 1)
+
+        row_y = y + 108
+        for index, item in enumerate(visible_sessions):
+            row_color = self.PANEL_STRONG if index == 0 else self.PANEL_ALT
+            self._draw_panel(
+                frame_bgr,
+                x + 18,
+                row_y - 15,
+                width - 36,
+                row_h,
+                color=row_color,
+                border_color=self.BORDER_ACTIVE if index == 0 else self.BORDER,
+                alpha=0.9,
+                radius=10,
+            )
+            self._put_text(
+                frame_bgr,
+                self._format_short_session_timestamp(item.folder_name),
+                session_x,
+                row_y,
+                0.3,
+                self.TEXT if index == 0 else self.MUTED,
+                max_width=max(120, reps_x - session_x - 12),
+            )
+            self._put_text(frame_bgr, str(item.rep_count), reps_x, row_y, 0.3, self.TEXT)
+            self._put_text(
+                frame_bgr,
+                self._format_percentage(item.bad_rep_percentage),
+                bad_x,
+                row_y,
+                0.3,
+                self.WARNING if (item.bad_rep_percentage or 0) > 0 else self.TEXT,
+            )
+            self._put_text(
+                frame_bgr,
+                self._format_angle(item.avg_knee_angle),
+                knee_x,
+                row_y,
+                0.3,
+                self.TEXT,
+            )
+            self._put_text(
+                frame_bgr,
+                self._format_issue(item.most_common_issue),
+                issue_x,
+                row_y,
+                0.3,
+                self.WARNING if item.most_common_issue else self.PRIMARY,
+                max_width=x + width - issue_x - 24,
+            )
+            row_y += row_h + row_gap
+
+        footer_y = y + height - 34
+        self._put_text(
+            frame_bgr,
+            self._format_issue_totals_line(getattr(snapshot, "issue_totals", {})),
+            x + 24,
+            footer_y,
+            0.34,
+            self.MUTED,
+            max_width=width - 48,
+        )
+        self._put_text(
+            frame_bgr,
+            self._format_fps_summary(snapshot),
+            x + 24,
+            footer_y + 18,
+            0.34,
+            self.MUTED,
+            max_width=width - 48,
+        )
+
     def _draw_progress_panel(self, frame_bgr, x, y, width, height, snapshot) -> None:
         self._draw_panel(
             frame_bgr,
@@ -1066,8 +1292,8 @@ class OverlayRenderer:
             frame_bgr,
             f"Previous: {self._format_session_timestamp(snapshot.previous_timestamp)}",
             x + 24,
-            y + 62,
-            scale=0.5,
+            y + 58,
+            scale=0.42 if height < 160 else 0.5,
             color=self.MUTED,
             thickness=1,
             max_width=width - 48,
@@ -1075,56 +1301,59 @@ class OverlayRenderer:
 
         card_gap = 10
         card_w = (width - 48 - (card_gap * 2)) // 3
-        card_y = y + 92
+        compact = height < 160
+        card_y = y + 76 if compact else y + 92
+        card_h = 44 if compact else 68
         self._draw_metric_tile(
             frame_bgr,
             x + 24,
             card_y,
             card_w,
-            68,
+            card_h,
             "Reps",
             self._format_change(snapshot.rep_count_change),
             self._change_color(snapshot.rep_count_change, positive_is_good=True),
-            label_scale=0.42,
-            value_scale=0.64,
+            label_scale=0.34 if compact else 0.42,
+            value_scale=0.42 if compact else 0.64,
         )
         self._draw_metric_tile(
             frame_bgr,
             x + 24 + card_w + card_gap,
             card_y,
             card_w,
-            68,
+            card_h,
             "Bad Rate",
             self._format_percentage_point_change(snapshot.bad_rep_percentage_change),
             self._change_color(
                 snapshot.bad_rep_percentage_change, positive_is_good=False
             ),
-            label_scale=0.42,
-            value_scale=0.52,
+            label_scale=0.34 if compact else 0.42,
+            value_scale=0.34 if compact else 0.52,
         )
         self._draw_metric_tile(
             frame_bgr,
             x + 24 + ((card_w + card_gap) * 2),
             card_y,
             card_w,
-            68,
+            card_h,
             "Avg Knee",
             self._format_angle_change(snapshot.avg_knee_angle_change),
             self.TEXT,
-            label_scale=0.42,
-            value_scale=0.52,
+            label_scale=0.34 if compact else 0.42,
+            value_scale=0.34 if compact else 0.52,
         )
 
-        self._put_text(
-            frame_bgr,
-            f"Previous rep count: {self._format_metric_value(snapshot.previous_rep_count)}",
-            x + 24,
-            y + height - 24,
-            scale=0.5,
-            color=self.MUTED,
-            thickness=1,
-            max_width=width - 48,
-        )
+        if not compact:
+            self._put_text(
+                frame_bgr,
+                f"Previous rep count: {self._format_metric_value(snapshot.previous_rep_count)}",
+                x + 24,
+                y + height - 24,
+                scale=0.5,
+                color=self.MUTED,
+                thickness=1,
+                max_width=width - 48,
+            )
 
     def _draw_session_report_panel(
         self, frame_bgr, x, y, width, height, snapshot
@@ -1147,13 +1376,43 @@ class OverlayRenderer:
             "Session Report",
             x + 34,
             y + 34,
-            scale=0.66,
+            scale=0.56 if height < 160 else 0.66,
             color=self.TEXT,
             thickness=1,
             max_width=width - 48,
         )
-        item_y = y + 66
-        gap = 42
+        compact = height < 160
+        if compact:
+            rows = [
+                ("Concern", snapshot.main_concern or "N/A", self.TEXT),
+                ("Suggestion", snapshot.suggested_improvement or "N/A", self.MUTED),
+                ("Focus", snapshot.focus_area or "N/A", self.PRIMARY),
+            ]
+            row_y = y + 58
+            for label, value, color in rows:
+                self._put_text(
+                    frame_bgr,
+                    f"{label}:",
+                    x + 34,
+                    row_y,
+                    0.32,
+                    self.MUTED,
+                    max_width=92,
+                )
+                self._put_text(
+                    frame_bgr,
+                    value,
+                    x + 116,
+                    row_y,
+                    0.32,
+                    color,
+                    max_width=width - 134,
+                )
+                row_y += 22
+            return
+
+        item_y = y + (48 if compact else 66)
+        gap = 23 if compact else 42
         self._draw_report_item(
             frame_bgr,
             x + 34,
@@ -1162,6 +1421,7 @@ class OverlayRenderer:
             "Main concern",
             snapshot.main_concern or "N/A",
             self.TEXT,
+            compact=compact,
         )
         self._draw_report_item(
             frame_bgr,
@@ -1171,6 +1431,7 @@ class OverlayRenderer:
             "Suggested improvement",
             snapshot.suggested_improvement or "N/A",
             self.MUTED,
+            compact=compact,
         )
         self._draw_report_item(
             frame_bgr,
@@ -1180,6 +1441,7 @@ class OverlayRenderer:
             "Focus area",
             snapshot.focus_area or "N/A",
             self.PRIMARY,
+            compact=compact,
         )
 
     def _draw_calibration_badge(
@@ -1456,8 +1718,9 @@ class OverlayRenderer:
         label_scale: float = 0.46,
         value_scale: float | None = None,
     ) -> None:
-        label_y = y + 22
-        value_y = y + height - 14
+        compact = height <= 64
+        label_y = y + (16 if compact else 22)
+        value_y = y + height - (7 if compact else 14)
         if value_scale is None:
             value_scale = 0.7 if height < 70 else 0.82
 
@@ -1501,14 +1764,24 @@ class OverlayRenderer:
         label: str,
         value: str,
         value_color: tuple[int, int, int],
+        *,
+        compact: bool = False,
     ) -> None:
-        self._put_text(frame_bgr, label, x, y, 0.44, self.MUTED, max_width=width)
+        self._put_text(
+            frame_bgr,
+            label,
+            x,
+            y,
+            0.34 if compact else 0.44,
+            self.MUTED,
+            max_width=width,
+        )
         self._put_text(
             frame_bgr,
             value,
             x,
-            y + 24,
-            scale=0.54,
+            y + (16 if compact else 24),
+            scale=0.34 if compact else 0.54,
             color=value_color,
             thickness=1,
             max_width=width,
@@ -2101,6 +2374,12 @@ class OverlayRenderer:
         return f"{value:.1f}%"
 
     @staticmethod
+    def _format_compact_percentage(value: float | None) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.0f}%"
+
+    @staticmethod
     def _format_change(value: int | None) -> str:
         if value is None:
             return "N/A"
@@ -2125,6 +2404,18 @@ class OverlayRenderer:
         return f"{value:.1f} deg"
 
     @staticmethod
+    def _format_compact_angle(value: float | None) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.0f}"
+
+    @staticmethod
+    def _format_fps(value: float | None) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.1f}"
+
+    @staticmethod
     def _format_angle_change(value: float | None) -> str:
         if value is None:
             return "N/A"
@@ -2135,6 +2426,20 @@ class OverlayRenderer:
         if not value:
             return "none"
         return value.replace("_", " ")
+
+    def _format_issue_totals_line(self, issue_totals: dict[str, int]) -> str:
+        if not issue_totals:
+            return "Issue totals: none recorded"
+
+        parts = []
+        for issue, count in list(issue_totals.items())[:3]:
+            parts.append(f"{self._format_issue(issue)} {count}")
+        return "Issue totals: " + " | ".join(parts)
+
+    def _format_fps_summary(self, snapshot) -> str:
+        latest = self._format_fps(getattr(snapshot, "latest_avg_fps", None))
+        overall = self._format_fps(getattr(snapshot, "avg_fps_overall", None))
+        return f"FPS: latest {latest} | overall average {overall}"
 
     @staticmethod
     def _camera_fallback_label(index: int) -> str:
@@ -2190,5 +2495,18 @@ class OverlayRenderer:
                 return (
                     f"{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
                     f"{time_part[0:2]}:{time_part[2:4]}:{time_part[4:6]}"
+                )
+        return value
+
+    @staticmethod
+    def _format_short_session_timestamp(value: str | None) -> str:
+        if not value:
+            return "N/A"
+        if len(value) == 15 and "_" in value:
+            date_part, time_part = value.split("_", maxsplit=1)
+            if len(date_part) == 8 and len(time_part) == 6:
+                return (
+                    f"{date_part[4:6]}-{date_part[6:8]} "
+                    f"{time_part[0:2]}:{time_part[2:4]}"
                 )
         return value


### PR DESCRIPTION
Closes #52 

What changed:
- Added recent meaningful-session trend data for analytics.
- Updated the analytics dashboard to show recent trends, issue breakdown, and FPS summary where available.
- Added local static HTML analytics export at exports/analytics_report.html.
- Added E key support on the analytics dashboard to generate and open the report.
- Preserved the existing squat detection, recording, browser, calibration, camera selection, theme support, and summary-saving flow.

How to run/test:
python src/app.py

Manual test steps:
- Open analytics dashboard with no meaningful sessions and confirm graceful empty state.
- Run one valid session and confirm analytics dashboard displays latest meaningful session.
- Run multiple valid sessions and confirm last 5 trend rows are shown.
- Confirm invalid/incomplete sessions are ignored from meaningful analytics.
- Confirm missing optional fields such as FPS or ankle angle show as N/A.
- Press E on the analytics dashboard.
- Confirm exports/analytics_report.html is created and opens in browser.

Evidence:
- Analytics dashboard now shows recent trends and issue breakdown.
- HTML analytics report provides project-level evidence for final report, poster, and viva.