### PR TITLE
Add automated pytest suite for core GymGuardian logic

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -137,3 +137,78 @@ This document defines the manual test plan for the GymGuardian MVP desktop appli
 - Browser screenshot: `Yes`
 - Sample `summary.json`: `Yes`
 - Sample `session.mp4`: `Yes`
+
+## 9. Evaluation Harness
+
+GymGuardian includes a report-focused evaluation harness for comparing manually
+labelled saved sessions against detected session outputs. The label file is
+stored at `docs/evaluation/manual_labels.csv`.
+
+### Labelling Process
+
+1. Review a saved `session.mp4` from `sessions/<timestamp>/`.
+2. Count the visible completed squat repetitions manually.
+3. Count how many repetitions should be classified as bad.
+4. Record the expected main issue, such as `too_shallow`, `ankle_control`,
+   `torso_lean`, or `none`.
+5. Optionally record a per-repetition bad sequence using `0` for good and `1`
+   for bad, for example `0,0,1,1`.
+
+### Running the Harness
+
+```powershell
+.\venv\Scripts\python.exe src\session\evaluation_export.py
+```
+
+The harness exports:
+
+- `exports/evaluation_results.csv`
+- `exports/evaluation_report.html`
+
+### Metrics Produced
+
+- Rep count error and rep count accuracy
+- Bad-rep count error and bad-rep rate difference
+- Issue match against the manually expected issue
+- Optional bad-rep precision and recall from per-rep labels
+- Average FPS from saved session summaries
+
+This evaluates the full GymGuardian system output. It should not be described
+as custom model-training accuracy because the project uses MediaPipe pose
+estimation with rule-based squat analysis.
+
+## 10. Automated Testing
+
+Automated testing was added to support supervisor feedback and strengthen the
+final evaluation evidence. These tests focus on deterministic project logic
+that can run without a webcam.
+
+### Automated Test Command
+
+```powershell
+.\venv\Scripts\python.exe -m pytest
+```
+
+### Automated Coverage
+
+| Test Area | Automated Coverage |
+| --- | --- |
+| Squat logic | Joint-angle calculation, full-depth rep counting, shallow-rep classification, and no-pose reset handling |
+| Session summary | `summary.json`, `rep_metrics.csv`, `session_report.txt`, and `valid_session` output |
+| Analytics | Meaningful-session filtering, latest/previous comparison, issue totals, and FPS averaging |
+| Calibration/settings | Adaptive threshold generation, invalid calibration rejection, and settings normalization |
+| Evaluation harness | Manual label parsing, valid-session scoring, missing sessions, incomplete sessions, and sequence precision/recall |
+
+### Documentation Note
+
+The automated suite validates application logic and saved-output processing. It
+does not claim to test MediaPipe model accuracy or webcam performance. Live
+camera behaviour, lighting sensitivity, and camera-angle limitations remain part
+of the manual scenario-based evaluation.
+
+### Evidence To Capture
+
+- Screenshot of the terminal command `.\venv\Scripts\python.exe -m pytest`.
+- Screenshot showing the final result, for example `13 passed`.
+- Include the command and result in the Testing and Evaluation section of the
+  final report.

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ sentencepiece==0.2.1
 six==1.17.0
 sounddevice==0.5.2
 threadpoolctl==3.6.0
+pytest==8.3.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+﻿"""Shared pytest setup for GymGuardian tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,81 @@
+﻿"""Automated tests for saved-session analytics loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from session.browser import list_recent_sessions, load_analytics_snapshot
+
+
+def _write_summary(sessions_dir: Path, folder_name: str, data: dict) -> None:
+    folder = sessions_dir / folder_name
+    folder.mkdir(parents=True)
+    (folder / "summary.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_analytics_uses_latest_meaningful_session_and_previous_meaningful_session(tmp_path) -> None:
+    _write_summary(
+        tmp_path,
+        "20260503_120000",
+        {"valid_session": False, "rep_count": 0, "bad_rep_count": 0},
+    )
+    _write_summary(
+        tmp_path,
+        "20260502_120000",
+        {
+            "valid_session": True,
+            "rep_count": 10,
+            "bad_rep_count": 2,
+            "avg_knee_angle": 140.0,
+            "min_knee_angle": 90.0,
+            "avg_ankle_angle": 88.0,
+            "avg_torso_angle": 10.0,
+            "avg_fps": 18.0,
+            "issue_counts": {"too_shallow": 2},
+            "most_common_issue": "too_shallow",
+        },
+    )
+    _write_summary(
+        tmp_path,
+        "20260501_120000",
+        {
+            "valid_session": True,
+            "rep_count": 8,
+            "bad_rep_count": 1,
+            "avg_knee_angle": 130.0,
+            "min_knee_angle": 85.0,
+            "avg_ankle_angle": 84.0,
+            "avg_torso_angle": 8.0,
+            "avg_fps": 16.0,
+            "issue_counts": {"ankle_control": 1},
+            "most_common_issue": "ankle_control",
+        },
+    )
+
+    snapshot = load_analytics_snapshot(tmp_path)
+
+    assert snapshot.total_sessions == 3
+    assert snapshot.meaningful_session_count == 2
+    assert snapshot.latest_timestamp == "20260502_120000"
+    assert snapshot.previous_timestamp == "20260501_120000"
+    assert snapshot.latest_rep_count == 10
+    assert snapshot.latest_bad_rep_percentage == 20.0
+    assert snapshot.rep_count_change == 2
+    assert snapshot.bad_rep_percentage_change == 7.5
+    assert snapshot.avg_knee_angle_change == 10.0
+    assert snapshot.issue_totals == {"too_shallow": 2, "ankle_control": 1}
+    assert snapshot.avg_fps_overall == 17.0
+    assert len(snapshot.trend_sessions) == 2
+
+
+def test_session_browser_marks_incomplete_sessions_without_crashing(tmp_path) -> None:
+    _write_summary(tmp_path, "20260503_120000", {"rep_count": 0, "bad_rep_count": 0})
+    _write_summary(tmp_path, "20260502_120000", {"rep_count": 3, "bad_rep_count": 1})
+
+    sessions = list_recent_sessions(tmp_path, limit=None)
+
+    assert sessions[0].valid_session is False
+    assert sessions[0].folder_name.endswith("(incomplete)")
+    assert sessions[1].valid_session is True
+    assert sessions[1].folder_name == "20260502_120000"

--- a/tests/test_evaluation_export.py
+++ b/tests/test_evaluation_export.py
@@ -1,0 +1,153 @@
+﻿"""Automated tests for the manual-label evaluation export harness."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import session.evaluation_export as evaluation_export
+from session.evaluation_export import (
+    aggregate_results,
+    evaluate_label,
+    export_evaluation_report,
+    load_manual_labels,
+)
+
+
+LABEL_COLUMNS = [
+    "case_id",
+    "scenario",
+    "session_folder",
+    "manual_rep_count",
+    "manual_bad_rep_count",
+    "expected_issue",
+    "manual_bad_sequence",
+    "lighting",
+    "camera_angle",
+    "notes",
+]
+
+
+def _write_labels(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=LABEL_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_session(sessions_dir: Path, folder_name: str, summary: dict, sequence: list[int] | None = None) -> None:
+    folder = sessions_dir / folder_name
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    if sequence is not None:
+        with (folder / "rep_metrics.csv").open("w", encoding="utf-8", newline="") as file:
+            writer = csv.writer(file)
+            writer.writerow(["rep_index", "timestamp_seconds", "is_bad", "issues"])
+            for index, is_bad in enumerate(sequence, start=1):
+                writer.writerow([index, f"{index:.2f}", is_bad, "too_shallow" if is_bad else ""])
+
+
+def test_evaluation_export_scores_labelled_valid_session(tmp_path, monkeypatch) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(evaluation_export, "SESSIONS_DIR", sessions_dir)
+    _write_session(
+        sessions_dir,
+        "20260509_120000",
+        {
+            "valid_session": True,
+            "rep_count": 4,
+            "bad_rep_count": 2,
+            "issue_counts": {"too_shallow": 2},
+            "most_common_issue": "too_shallow",
+            "avg_fps": 18.5,
+        },
+        sequence=[0, 1, 0, 1],
+    )
+    labels_path = tmp_path / "manual_labels.csv"
+    _write_labels(
+        labels_path,
+        [
+            {
+                "case_id": "AUTO-01",
+                "scenario": "mixed squats",
+                "session_folder": "20260509_120000",
+                "manual_rep_count": 4,
+                "manual_bad_rep_count": 2,
+                "expected_issue": "too_shallow",
+                "manual_bad_sequence": "0,1,0,1",
+                "lighting": "indoor",
+                "camera_angle": "front-facing",
+                "notes": "automated smoke row",
+            }
+        ],
+    )
+
+    results_csv, report_html = export_evaluation_report(
+        labels_path=labels_path,
+        results_csv_path=tmp_path / "evaluation_results.csv",
+        report_html_path=tmp_path / "evaluation_report.html",
+    )
+
+    assert results_csv.exists()
+    assert report_html.exists()
+    labels = load_manual_labels(labels_path)
+    result = evaluate_label(labels[0])
+    assert result.status == "evaluated"
+    assert result.rep_accuracy_percent == 100.0
+    assert result.bad_rate_difference == 0.0
+    assert result.issue_match == "match"
+    assert result.sequence_precision == 100.0
+    assert result.sequence_recall == 100.0
+
+
+def test_evaluation_handles_missing_session_and_incomplete_session(tmp_path, monkeypatch) -> None:
+    sessions_dir = tmp_path / "sessions"
+    monkeypatch.setattr(evaluation_export, "SESSIONS_DIR", sessions_dir)
+    _write_session(
+        sessions_dir,
+        "20260509_000000",
+        {"valid_session": False, "rep_count": 0, "bad_rep_count": 0, "avg_fps": 12.0},
+    )
+
+    labels_path = tmp_path / "manual_labels.csv"
+    _write_labels(
+        labels_path,
+        [
+            {
+                "case_id": "MISS-01",
+                "scenario": "missing folder",
+                "session_folder": "missing_folder",
+                "manual_rep_count": 0,
+                "manual_bad_rep_count": 0,
+                "expected_issue": "none",
+                "manual_bad_sequence": "",
+                "lighting": "indoor",
+                "camera_angle": "front-facing",
+                "notes": "",
+            },
+            {
+                "case_id": "INC-01",
+                "scenario": "empty session",
+                "session_folder": "20260509_000000",
+                "manual_rep_count": 0,
+                "manual_bad_rep_count": 0,
+                "expected_issue": "none",
+                "manual_bad_sequence": "",
+                "lighting": "indoor",
+                "camera_angle": "front-facing",
+                "notes": "",
+            },
+        ],
+    )
+
+    labels = load_manual_labels(labels_path)
+    results = [evaluate_label(label) for label in labels]
+
+    assert results[0].status == "missing_session"
+    assert results[1].status == "incomplete_session"
+    aggregate = aggregate_results(results)
+    assert aggregate.evaluated_rows == 0
+    assert aggregate.skipped_rows == 2

--- a/tests/test_session_summary.py
+++ b/tests/test_session_summary.py
@@ -1,0 +1,61 @@
+﻿"""Automated tests for session summary evidence outputs."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime
+
+from session.summary import SessionSummary
+
+
+def test_session_summary_saves_valid_json_csv_and_text_report(tmp_path) -> None:
+    summary = SessionSummary(started_at=datetime(2026, 5, 9, 10, 30, 0))
+    summary.add_pose_metrics(knee_angle=95.0, ankle_angle=82.0, torso_angle=12.0)
+    summary.add_fps_sample(18.0)
+    summary.record_rep_start(1.0)
+    summary.record_rep_complete(2.0, reason="too_shallow")
+    summary.record_completed_rep(
+        rep_index=1,
+        timestamp=2.0,
+        is_bad=True,
+        issues=["too_shallow"],
+        min_knee_angle=118.0,
+        min_ankle_angle=86.0,
+        max_torso_angle=18.0,
+    )
+    summary.record_issue("too_shallow")
+    summary.rep_count = 1
+    summary.bad_rep_count = 1
+
+    summary_path = summary.save(tmp_path)
+
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert data["valid_session"] is True
+    assert data["rep_count"] == 1
+    assert data["bad_rep_count"] == 1
+    assert data["most_common_issue"] == "too_shallow"
+    assert data["avg_fps"] == 18.0
+
+    with (tmp_path / "rep_metrics.csv").open("r", encoding="utf-8", newline="") as file:
+        rows = list(csv.DictReader(file))
+    assert rows[0]["rep_index"] == "1"
+    assert rows[0]["is_bad"] == "1"
+    assert rows[0]["issues"] == "too_shallow"
+
+    report_text = (tmp_path / "session_report.txt").read_text(encoding="utf-8")
+    assert "Session status: valid" in report_text
+    assert "Focus area: Knee bend depth" in report_text
+
+
+def test_zero_rep_summary_is_marked_incomplete(tmp_path) -> None:
+    summary = SessionSummary(started_at=datetime(2026, 5, 9, 10, 30, 0))
+
+    summary_path = summary.save(tmp_path)
+
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert data["valid_session"] is False
+    assert data["rep_count"] == 0
+    assert "Session status: incomplete" in (tmp_path / "session_report.txt").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_squat_logic.py
+++ b/tests/test_squat_logic.py
@@ -1,0 +1,102 @@
+﻿"""Automated tests for squat angle and repetition logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from analysis.squat import SquatRepCounter, SquatState, _angle_degrees
+from core.config import SquatConfig
+
+
+def _state(knee: float, ankle: float = 70.0, torso: float = 8.0) -> SquatState:
+    if knee >= 160:
+        label = "standing"
+    elif knee <= 100:
+        label = "down"
+    else:
+        label = "transition"
+    return SquatState(
+        label=label,
+        knee_angle=knee,
+        ankle_angle=ankle,
+        torso_angle=torso,
+        pose_visible=True,
+    )
+
+
+def _test_config() -> SquatConfig:
+    return SquatConfig(
+        down_knee_angle=100.0,
+        up_knee_angle=160.0,
+        rep_bottom_knee_angle=140.0,
+        shallow_knee_angle=110.0,
+        ankle_control_angle=88.0,
+        torso_lean_angle=34.0,
+        down_hold_frames=2,
+        ready_standing_frames=2,
+        no_pose_reset_frames=2,
+        min_rep_seconds=0.2,
+    )
+
+
+def test_angle_degrees_returns_angle_at_middle_point() -> None:
+    assert _angle_degrees((1, 0), (0, 0), (0, 1)) == pytest.approx(90.0)
+    assert _angle_degrees((1, 0), (0, 0), (1, 0)) == pytest.approx(0.0)
+
+
+def test_rep_counter_counts_full_depth_rep_as_good() -> None:
+    counter = SquatRepCounter(_test_config())
+
+    updates = [
+        counter.update(_state(170), 0.0),
+        counter.update(_state(170), 0.1),
+        counter.update(_state(130), 0.2),
+        counter.update(_state(95), 0.3),
+        counter.update(_state(90), 0.4),
+        counter.update(_state(170), 0.7),
+    ]
+
+    assert any(update.rep_started for update in updates)
+    complete = updates[-1]
+    assert complete.rep_completed is True
+    assert complete.is_bad is False
+    assert complete.issues == ()
+    assert counter.rep_count == 1
+    assert counter.bad_rep_count == 0
+    assert counter.last_rep_result == "ok"
+
+
+def test_rep_counter_flags_shallow_rep_as_bad() -> None:
+    counter = SquatRepCounter(_test_config())
+
+    for timestamp, knee in [
+        (0.0, 170),
+        (0.1, 170),
+        (0.2, 132),
+        (0.3, 130),
+        (0.4, 128),
+    ]:
+        counter.update(_state(knee), timestamp)
+    complete = counter.update(_state(170), 0.7)
+
+    assert complete.rep_completed is True
+    assert complete.is_bad is True
+    assert "too_shallow" in complete.issues
+    assert counter.rep_count == 1
+    assert counter.bad_rep_count == 1
+
+
+def test_no_pose_resets_incomplete_cycle_before_counting() -> None:
+    counter = SquatRepCounter(_test_config())
+    no_pose = SquatState(label="no_pose", knee_angle=None, pose_visible=False)
+
+    counter.update(_state(170), 0.0)
+    counter.update(_state(170), 0.1)
+    counter.update(_state(130), 0.2)
+    counter.update(no_pose, 0.3)
+    counter.update(no_pose, 0.4)
+    complete = counter.update(_state(170), 0.8)
+
+    assert complete.rep_completed is False
+    assert counter.rep_count == 0
+    assert counter.bad_rep_count == 0

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,0 +1,46 @@
+﻿"""Automated tests for calibration and local settings helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+import core.user_profile as user_profile
+from core.user_profile import AppSettings, build_calibration_profile, load_app_settings, save_app_settings
+
+
+def test_build_calibration_profile_creates_ordered_adaptive_thresholds() -> None:
+    samples = ([170.0, 172.0, 168.0] * 12) + ([82.0, 84.0, 86.0] * 12)
+
+    profile = build_calibration_profile(samples)
+    config = profile.to_squat_config()
+
+    assert profile.sample_count == len(samples)
+    assert profile.lowest_knee_angle < profile.standing_knee_angle
+    assert profile.lowest_knee_angle < config.down_knee_angle
+    assert config.down_knee_angle < config.shallow_knee_angle
+    assert config.shallow_knee_angle < config.rep_bottom_knee_angle
+    assert config.rep_bottom_knee_angle < config.up_knee_angle
+    assert config.up_knee_angle < profile.standing_knee_angle
+
+
+def test_build_calibration_profile_rejects_insufficient_or_tiny_movement_samples() -> None:
+    with pytest.raises(ValueError, match="Not enough"):
+        build_calibration_profile([170.0] * 5)
+
+    with pytest.raises(ValueError, match="Movement range"):
+        build_calibration_profile([160.0, 162.0, 161.0] * 12)
+
+
+def test_app_settings_persist_and_normalize_values(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(user_profile, "PROFILE_DIR", tmp_path)
+    monkeypatch.setattr(user_profile, "SETTINGS_FILE", tmp_path / "settings.json")
+
+    saved = save_app_settings(
+        AppSettings(theme="neon", hide_incomplete_sessions=True, camera_index=99)
+    )
+    loaded = load_app_settings()
+
+    assert saved.theme == "light"
+    assert saved.hide_incomplete_sessions is True
+    assert saved.camera_index == 0
+    assert loaded == saved


### PR DESCRIPTION
Closes #56 

## What changed
- Added pytest as a development/testing dependency.
- Added automated tests for deterministic GymGuardian logic.
- Covered squat angle and rep-count logic, shallow/bad rep classification, no-pose reset handling, session summary output, valid/incomplete session handling, analytics filtering, calibration helpers, settings normalization, and evaluation export logic.
- Updated the test plan documentation with automated testing coverage and report evidence notes.

## Why
Supervisor feedback requested automated testing evidence where possible. The webcam and MediaPipe live pipeline depends on hardware, lighting, and camera positioning, so automated tests focus on deterministic logic that can be tested reliably without a camera.

## How to run/test
```powershell
.\venv\Scripts\python.exe -m pytest