### PR TITLE
fix: stabilise squat detection and live overlay readability

### DIFF
--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -17,6 +17,14 @@ class SquatState:
     ankle_angle: Optional[float] = None
     torso_angle: Optional[float] = None
     pose_visible: bool = False
+    quality_knee_angle: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class _AngleCandidate:
+    side: str
+    angle: float
+    confidence: float
 
 
 class SquatStateAnalyzer:
@@ -26,9 +34,11 @@ class SquatStateAnalyzer:
         self._config = config or SQUAT_CONFIG
         window = max(1, self._config.angle_smoothing_window)
         self._knee_history: Deque[float] = deque(maxlen=window)
+        self._quality_knee_history: Deque[float] = deque(maxlen=window)
         self._ankle_history: Deque[float] = deque(maxlen=window)
         self._torso_history: Deque[float] = deque(maxlen=window)
         self._missing_pose_frames = 0
+        self._active_side: Optional[str] = None
 
     def classify(self, pose_result) -> SquatState:
         # pose_result.pose_landmarks -> list of poses; each pose -> list of landmarks
@@ -41,22 +51,45 @@ class SquatStateAnalyzer:
 
         landmarks = pose_result.pose_landmarks[0]
 
-        raw_knee_angle = self._angle_if_visible(landmarks, 23, 25, 27)
-        if raw_knee_angle is None:
-            # Treat partial lower-body detection as no pose for rep logic.
+        left_knee = self._angle_candidate_if_visible(landmarks, "left", 23, 25, 27)
+        right_knee = self._angle_candidate_if_visible(landmarks, "right", 24, 26, 28)
+        knee_candidate = self._select_angle_candidate(
+            left_knee,
+            right_knee,
+            prefer_lower=True,
+        )
+        if knee_candidate is None:
+            # Treat missing lower-body landmarks on both sides as no pose for rep logic.
             self._mark_missing_pose()
             return SquatState(label="no_pose", knee_angle=None)
 
-        knee_angle = self._smooth_metric(self._knee_history, raw_knee_angle)
-        ankle_angle = self._maybe_smooth_angle(
-            self._ankle_history,
-            self._angle_if_visible(landmarks, 25, 27, 31),
-            self._angle_if_visible(landmarks, 26, 28, 32),
+        self._sync_active_side(knee_candidate.side)
+        knee_angle = self._smooth_metric(self._knee_history, knee_candidate.angle)
+        quality_knee_angle = self._smooth_metric(
+            self._quality_knee_history,
+            self._quality_knee_angle(knee_candidate, left_knee, right_knee),
         )
-        torso_angle = self._maybe_smooth_angle(
-            self._torso_history,
-            self._torso_angle_if_visible(landmarks, 11, 23),
-            self._torso_angle_if_visible(landmarks, 12, 24),
+
+        ankle_candidate = self._side_candidate_or_best(
+            landmarks,
+            knee_candidate.side,
+            ("left", 25, 27, 31),
+            ("right", 26, 28, 32),
+            prefer_lower=False,
+        )
+        torso_candidate = self._torso_side_candidate_or_best(
+            landmarks,
+            knee_candidate.side,
+        )
+        ankle_angle = (
+            self._smooth_metric(self._ankle_history, ankle_candidate.angle)
+            if ankle_candidate is not None
+            else None
+        )
+        torso_angle = (
+            self._smooth_metric(self._torso_history, torso_candidate.angle)
+            if torso_candidate is not None
+            else None
         )
 
         self._missing_pose_frames = 0
@@ -73,26 +106,117 @@ class SquatStateAnalyzer:
             ankle_angle=ankle_angle,
             torso_angle=torso_angle,
             pose_visible=True,
+            quality_knee_angle=quality_knee_angle,
         )
 
-    def _angle_if_visible(
-        self, landmarks, point_a: int, point_b: int, point_c: int
-    ) -> Optional[float]:
+    def _angle_candidate_if_visible(
+        self, landmarks, side: str, point_a: int, point_b: int, point_c: int
+    ) -> Optional[_AngleCandidate]:
         if not self._landmarks_visible(landmarks, point_a, point_b, point_c):
             return None
 
         landmark_a = landmarks[point_a]
         landmark_b = landmarks[point_b]
         landmark_c = landmarks[point_c]
-        return _angle_degrees(
+        angle = _angle_degrees(
             (landmark_a.x, landmark_a.y),
             (landmark_b.x, landmark_b.y),
             (landmark_c.x, landmark_c.y),
         )
+        confidence = min(
+            self._landmark_confidence(landmark_a),
+            self._landmark_confidence(landmark_b),
+            self._landmark_confidence(landmark_c),
+        )
+        return _AngleCandidate(side=side, angle=angle, confidence=confidence)
+
+    def _select_angle_candidate(
+        self,
+        first: Optional[_AngleCandidate],
+        second: Optional[_AngleCandidate],
+        *,
+        prefer_lower: bool,
+    ) -> Optional[_AngleCandidate]:
+        candidates = [candidate for candidate in (first, second) if candidate is not None]
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+
+        left, right = candidates
+        if abs(left.confidence - right.confidence) >= 0.15:
+            return max(candidates, key=lambda candidate: candidate.confidence)
+        if prefer_lower:
+            return min(candidates, key=lambda candidate: candidate.angle)
+        return max(candidates, key=lambda candidate: candidate.confidence)
+
+    def _quality_knee_angle(
+        self,
+        selected: _AngleCandidate,
+        first: Optional[_AngleCandidate],
+        second: Optional[_AngleCandidate],
+    ) -> float:
+        candidates = [candidate for candidate in (first, second) if candidate is not None]
+        if len(candidates) <= 1:
+            return selected.angle
+
+        best_confidence = max(candidate.confidence for candidate in candidates)
+        reliable = [
+            candidate
+            for candidate in candidates
+            if best_confidence - candidate.confidence <= 0.12
+        ]
+        if not reliable:
+            return selected.angle
+        # Quality checks are conservative: one noisy-looking deep side should not
+        # hide a shallow rep when the other side remains reliably visible.
+        return max(candidate.angle for candidate in reliable)
+
+    def _side_candidate_or_best(
+        self,
+        landmarks,
+        preferred_side: str,
+        left_points: tuple[str, int, int, int],
+        right_points: tuple[str, int, int, int],
+        *,
+        prefer_lower: bool,
+    ) -> Optional[_AngleCandidate]:
+        left = self._angle_candidate_if_visible(landmarks, *left_points)
+        right = self._angle_candidate_if_visible(landmarks, *right_points)
+        preferred = left if preferred_side == "left" else right
+        if preferred is not None:
+            return preferred
+        return self._select_angle_candidate(left, right, prefer_lower=prefer_lower)
+
+    def _torso_side_candidate_or_best(
+        self, landmarks, preferred_side: str
+    ) -> Optional[_AngleCandidate]:
+        left = self._torso_candidate_if_visible(landmarks, "left", 11, 23)
+        right = self._torso_candidate_if_visible(landmarks, "right", 12, 24)
+        preferred = left if preferred_side == "left" else right
+        if preferred is not None:
+            return preferred
+        return self._select_angle_candidate(left, right, prefer_lower=False)
+
+    def _angle_if_visible(
+        self, landmarks, point_a: int, point_b: int, point_c: int
+    ) -> Optional[float]:
+        candidate = self._angle_candidate_if_visible(
+            landmarks, "unknown", point_a, point_b, point_c
+        )
+        return candidate.angle if candidate is not None else None
 
     def _torso_angle_if_visible(
         self, landmarks, shoulder_i: int, hip_i: int
     ) -> Optional[float]:
+        candidate = self._torso_candidate_if_visible(
+            landmarks, "unknown", shoulder_i, hip_i
+        )
+        return candidate.angle if candidate is not None else None
+
+    def _torso_candidate_if_visible(
+        self, landmarks, side: str, shoulder_i: int, hip_i: int
+    ) -> Optional[_AngleCandidate]:
         if not self._landmarks_visible(landmarks, shoulder_i, hip_i):
             return None
 
@@ -100,14 +224,20 @@ class SquatStateAnalyzer:
         hip = landmarks[hip_i]
         dx = shoulder.x - hip.x
         dy = shoulder.y - hip.y
-        if dx == 0 and dy == 0:
-            return 0.0
 
         vertical_span = abs(dy)
-        if vertical_span == 0:
-            return 90.0
+        if dx == 0 and dy == 0:
+            angle = 0.0
+        elif vertical_span == 0:
+            angle = 90.0
+        else:
+            angle = math.degrees(math.atan2(abs(dx), vertical_span))
 
-        return math.degrees(math.atan2(abs(dx), vertical_span))
+        confidence = min(
+            self._landmark_confidence(shoulder),
+            self._landmark_confidence(hip),
+        )
+        return _AngleCandidate(side=side, angle=angle, confidence=confidence)
 
     def _maybe_smooth_angle(
         self,
@@ -124,16 +254,42 @@ class SquatStateAnalyzer:
         history.append(value)
         return sum(history) / len(history)
 
+    def _sync_active_side(self, side: str) -> None:
+        if self._active_side is not None and self._active_side != side:
+            self._knee_history.clear()
+            self._quality_knee_history.clear()
+            self._ankle_history.clear()
+            self._torso_history.clear()
+        self._active_side = side
+
     def _mark_missing_pose(self) -> None:
         self._missing_pose_frames += 1
         if self._missing_pose_frames >= self._config.no_pose_reset_frames:
             self._knee_history.clear()
+            self._quality_knee_history.clear()
             self._ankle_history.clear()
             self._torso_history.clear()
+            self._active_side = None
 
     def _landmarks_visible(self, landmarks, *indices: int) -> bool:
-        visibilities = [getattr(landmarks[index], "visibility", 1.0) for index in indices]
-        return min(visibilities) >= self._config.landmark_visibility_threshold
+        if not landmarks or max(indices) >= len(landmarks):
+            return False
+        confidences = [self._landmark_confidence(landmarks[index]) for index in indices]
+        coords_ok = all(
+            math.isfinite(getattr(landmarks[index], "x", float("nan")))
+            and math.isfinite(getattr(landmarks[index], "y", float("nan")))
+            for index in indices
+        )
+        return coords_ok and min(confidences) >= self._config.landmark_visibility_threshold
+
+    @staticmethod
+    def _landmark_confidence(landmark) -> float:
+        visibility = getattr(landmark, "visibility", 1.0)
+        presence = getattr(landmark, "presence", visibility)
+        try:
+            return min(float(visibility), float(presence))
+        except (TypeError, ValueError):
+            return 0.0
 
 
 
@@ -177,7 +333,7 @@ class SquatRepCounter:
         self._missing_pose_frames = 0
         self._in_rep = False
         self._ready_for_rep = False
-        self._rep_start_time = 0.0
+        self._rep_start_time: Optional[float] = None
         self._min_knee_angle: Optional[float] = None
         self._min_ankle_angle: Optional[float] = None
         self._max_torso_angle: Optional[float] = None
@@ -197,6 +353,7 @@ class SquatRepCounter:
             if not self._in_rep and self._standing_frames >= self._config.ready_standing_frames:
                 self._ready_for_rep = True
                 self._bottom_frames = 0
+                self._rep_start_time = None
                 self._clear_cycle_metrics()
         else:
             self._standing_frames = 0
@@ -204,7 +361,8 @@ class SquatRepCounter:
         if self._in_rep:
             self._update_cycle_metrics(squat_state)
             if (
-                timestamp - self._rep_start_time >= self._config.min_rep_seconds
+                self._rep_start_time is not None
+                and timestamp - self._rep_start_time >= self._config.min_rep_seconds
                 and angle >= self._config.up_knee_angle
             ):
                 return self._complete_rep()
@@ -214,13 +372,16 @@ class SquatRepCounter:
             return RepCounterUpdate()
 
         if angle < self._config.up_knee_angle:
+            if self._rep_start_time is None:
+                self._rep_start_time = timestamp
             self._update_cycle_metrics(squat_state)
 
         if angle <= self._config.rep_bottom_knee_angle:
             self._bottom_frames += 1
             if self._bottom_frames >= self._config.down_hold_frames:
                 self._in_rep = True
-                self._rep_start_time = timestamp
+                if self._rep_start_time is None:
+                    self._rep_start_time = timestamp
                 return RepCounterUpdate(
                     rep_started=True,
                     min_knee_angle=self._min_knee_angle,
@@ -241,7 +402,11 @@ class SquatRepCounter:
         return RepCounterUpdate()
 
     def _update_cycle_metrics(self, squat_state: SquatState) -> None:
-        knee_angle = squat_state.knee_angle
+        knee_angle = (
+            squat_state.quality_knee_angle
+            if squat_state.quality_knee_angle is not None
+            else squat_state.knee_angle
+        )
         if knee_angle is not None:
             if self._min_knee_angle is None:
                 self._min_knee_angle = knee_angle
@@ -311,5 +476,5 @@ class SquatRepCounter:
         self._standing_frames = 0
         self._in_rep = False
         self._ready_for_rep = keep_ready
-        self._rep_start_time = 0.0
+        self._rep_start_time = None
         self._clear_cycle_metrics()

--- a/src/app.py
+++ b/src/app.py
@@ -228,13 +228,13 @@ def _current_feedback(
 
 def _rep_feedback(issues: tuple[str, ...], is_bad: bool) -> tuple[str, str]:
     if is_bad and "too_shallow" in issues:
-        return "Bad rep: increase squat depth", "bad"
+        return "Bad rep: lower hips and bend knees more", "bad"
     if "torso_lean" in issues and "ankle_control" in issues:
-        return "Rep logged: improve torso and ankle control", "warning"
+        return "Rep logged: feet flat, knees over toes, chest up", "warning"
     if "torso_lean" in issues:
-        return "Rep logged: reduce forward torso lean", "warning"
+        return "Rep logged: brace core and keep chest up", "warning"
     if "ankle_control" in issues:
-        return "Rep logged: improve ankle control", "warning"
+        return "Rep logged: keep feet flat; knees track over toes", "warning"
     return "Rep accepted", "ok"
 
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -15,18 +15,18 @@ class PoseConfig:
 
 @dataclass(frozen=True)
 class SquatConfig:
-    down_knee_angle: float = 100.0
+    down_knee_angle: float = 105.0
     up_knee_angle: float = 160.0
-    rep_bottom_knee_angle: float = 140.0
+    rep_bottom_knee_angle: float = 150.0
     shallow_knee_angle: float = 110.0
-    ankle_control_angle: float = 88.0
+    ankle_control_angle: float = 172.0
     torso_lean_angle: float = 34.0
-    landmark_visibility_threshold: float = 0.55
+    landmark_visibility_threshold: float = 0.45
     angle_smoothing_window: int = 5
-    down_hold_frames: int = 6
-    ready_standing_frames: int = 3
+    down_hold_frames: int = 4
+    ready_standing_frames: int = 2
     no_pose_reset_frames: int = 4
-    min_rep_seconds: float = 0.6
+    min_rep_seconds: float = 0.45
 
 
 @dataclass(frozen=True)

--- a/src/core/user_profile.py
+++ b/src/core/user_profile.py
@@ -28,12 +28,32 @@ class CalibrationProfile:
     calibrated_up_angle: float
 
     def to_squat_config(self) -> SquatConfig:
+        calibrated_up_angle = self.calibrated_up_angle
+        calibrated_shallow_angle = min(
+            self.calibrated_shallow_angle,
+            SQUAT_CONFIG.shallow_knee_angle,
+        )
+        calibrated_rep_bottom_angle = max(
+            self.calibrated_rep_bottom_angle,
+            SQUAT_CONFIG.rep_bottom_knee_angle,
+        )
+        calibrated_rep_bottom_angle = min(
+            calibrated_rep_bottom_angle,
+            calibrated_up_angle - 8.0,
+        )
+        calibrated_down_angle = min(
+            self.calibrated_down_angle,
+            calibrated_rep_bottom_angle - 20.0,
+        )
+        if calibrated_up_angle <= calibrated_rep_bottom_angle + 5.0:
+            return SQUAT_CONFIG
+
         return replace(
             SQUAT_CONFIG,
-            down_knee_angle=self.calibrated_down_angle,
-            shallow_knee_angle=self.calibrated_shallow_angle,
-            rep_bottom_knee_angle=self.calibrated_rep_bottom_angle,
-            up_knee_angle=self.calibrated_up_angle,
+            down_knee_angle=calibrated_down_angle,
+            shallow_knee_angle=calibrated_shallow_angle,
+            rep_bottom_knee_angle=calibrated_rep_bottom_angle,
+            up_knee_angle=calibrated_up_angle,
         )
 
 

--- a/src/session/insights.py
+++ b/src/session/insights.py
@@ -16,7 +16,7 @@ def build_recommendation(issue: Optional[str]) -> tuple[str, str, str]:
     if _issue_matches(normalized_issue, ("ankle", "foot", "stability")):
         return (
             "Ankle control is the main concern.",
-            "Improve ankle stability and foot positioning.",
+            "Keep feet planted and let knees track over toes without heel lift.",
             "Ankle control",
         )
     if _issue_matches(normalized_issue, ("torso", "back", "lean", "posture")):

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -120,6 +120,11 @@ class OverlayRenderer:
             feedback_level,
             calibration_profile,
         )
+        if feedback_message and (
+            feedback_level in {"ok", "bad"}
+            or feedback_message.startswith("Rep logged")
+        ):
+            self._draw_feedback(frame_bgr, feedback_message, feedback_level)
 
     def draw_dashboard(
         self,
@@ -170,10 +175,10 @@ class OverlayRenderer:
             "GymGuardian",
             shell_x + 58,
             shell_y + 150,
-            scale=1.48,
+            scale=1.38,
             color=self.PRIMARY,
             thickness=2,
-            max_width=470,
+            max_width=390,
         )
         self._put_text(
             frame_bgr,
@@ -192,7 +197,7 @@ class OverlayRenderer:
             camera_options,
             include_index=True,
         )
-        insight_w = 170
+        insight_w = 190
         insight_gap = 14
         insight_x = shell_x + shell_w - (insight_w * 3) - (insight_gap * 2) - 48
         insight_y = shell_y + 58
@@ -1268,6 +1273,7 @@ class OverlayRenderer:
         )
 
     def _draw_progress_panel(self, frame_bgr, x, y, width, height, snapshot) -> None:
+        compact = height < 160
         self._draw_panel(
             frame_bgr,
             x,
@@ -1282,8 +1288,8 @@ class OverlayRenderer:
             frame_bgr,
             "Progress Comparison",
             x + 24,
-            y + 34,
-            scale=0.66,
+            y + (30 if compact else 34),
+            scale=0.54 if compact else 0.66,
             color=self.TEXT,
             thickness=1,
             max_width=width - 48,
@@ -1292,7 +1298,7 @@ class OverlayRenderer:
             frame_bgr,
             f"Previous: {self._format_session_timestamp(snapshot.previous_timestamp)}",
             x + 24,
-            y + 58,
+            y + (52 if compact else 58),
             scale=0.42 if height < 160 else 0.5,
             color=self.MUTED,
             thickness=1,
@@ -1301,7 +1307,6 @@ class OverlayRenderer:
 
         card_gap = 10
         card_w = (width - 48 - (card_gap * 2)) // 3
-        compact = height < 160
         card_y = y + 76 if compact else y + 92
         card_h = 44 if compact else 68
         self._draw_metric_tile(
@@ -1515,9 +1520,9 @@ class OverlayRenderer:
     ) -> None:
         panel_x = 24
         panel_y = 24
-        panel_w = 408
-        panel_h = 170
-        pad = 16
+        panel_w = 520
+        panel_h = 210
+        pad = 18
 
         self._draw_panel(
             frame_bgr,
@@ -1547,7 +1552,7 @@ class OverlayRenderer:
             frame_bgr,
             panel_x + panel_w - 166,
             panel_y + 16,
-            146,
+            150,
             24,
             calibration_profile,
             compact=True,
@@ -1557,16 +1562,16 @@ class OverlayRenderer:
             frame_bgr,
             state_text,
             panel_x + pad,
-            panel_y + 56,
-            scale=0.66,
+            panel_y + 66,
+            scale=0.82,
             color=state_color,
             thickness=2,
             max_width=panel_w - (pad * 2),
         )
 
-        chip_y = panel_y + 70
-        chip_w = 116
-        chip_gap = 8
+        chip_y = panel_y + 86
+        chip_w = 142
+        chip_gap = 12
         self._draw_angle_chip(
             frame_bgr, panel_x + pad, chip_y, chip_w, "Knee", squat_state.knee_angle
         )
@@ -1592,7 +1597,7 @@ class OverlayRenderer:
                 self._draw_live_focus_text(
                     frame_bgr,
                     panel_x + pad,
-                    panel_y + 146,
+                    panel_y + 184,
                     panel_w - (pad * 2),
                     feedback_message,
                     feedback_level,
@@ -1602,17 +1607,17 @@ class OverlayRenderer:
         self._draw_compact_count(
             frame_bgr,
             panel_x + pad,
-            panel_y + 104,
-            96,
+            panel_y + 126,
+            118,
             "Reps",
             str(rep_counter.rep_count),
             self.LIVE_TEXT,
         )
         self._draw_compact_count(
             frame_bgr,
-            panel_x + pad + 106,
-            panel_y + 104,
-            96,
+            panel_x + pad + 132,
+            panel_y + 126,
+            118,
             "Bad",
             str(rep_counter.bad_rep_count),
             self.ERROR if rep_counter.bad_rep_count else self.LIVE_TEXT,
@@ -1622,7 +1627,7 @@ class OverlayRenderer:
             self._draw_live_focus_text(
                 frame_bgr,
                 panel_x + pad,
-                panel_y + 160,
+                panel_y + 190,
                 panel_w - (pad * 2),
                 feedback_message,
                 feedback_level,
@@ -1633,8 +1638,8 @@ class OverlayRenderer:
                 frame_bgr,
                 f"Last rep: {last_text}",
                 panel_x + pad,
-                panel_y + 160,
-                scale=0.36,
+                panel_y + 190,
+                scale=0.42,
                 color=self.LIVE_MUTED,
                 thickness=1,
                 max_width=panel_w - (pad * 2),
@@ -1699,7 +1704,7 @@ class OverlayRenderer:
             message,
             x,
             y,
-            0.36,
+            0.48,
             color,
             thickness=1,
             max_width=width,
@@ -1797,17 +1802,19 @@ class OverlayRenderer:
             "info": self.TEXT,
         }
         color = colors.get(feedback_level, colors["info"])
-        scale = 0.72
-        thickness = 1
+        scale = 1.08
+        thickness = 2
         _, frame_w = frame_bgr.shape[:2]
-        max_panel_w = min(430, max(260, frame_w - 520))
-        display_text = self._fit_text(message, max_panel_w - 36, scale, thickness)
-        text_w = self._text_width(display_text, scale, thickness)
-        text_h = self._text_height(display_text, scale, thickness)
-        pad_x = 18
-        pad_y = 14
-        panel_w = max(250, text_w + (pad_x * 2))
-        panel_h = text_h + (pad_y * 2)
+        max_panel_w = min(680, max(360, frame_w - 560))
+        pad_x = 24
+        pad_y = 18
+        text_max_w = max_panel_w - (pad_x * 2)
+        lines = self._wrap_text(message, text_max_w, scale, thickness, max_lines=3)
+        text_w = max(self._text_width(line, scale, thickness) for line in lines)
+        text_h = self._text_height("Ag", scale, thickness)
+        line_gap = 8
+        panel_w = max(360, min(max_panel_w, text_w + (pad_x * 2)))
+        panel_h = (text_h * len(lines)) + (line_gap * (len(lines) - 1)) + (pad_y * 2)
         panel_x = frame_w - panel_w - 24
         panel_y = 24
 
@@ -1819,18 +1826,22 @@ class OverlayRenderer:
             panel_h,
             color=self.BG_SOFT,
             border_color=color,
-            alpha=0.84,
+            alpha=0.92,
+            radius=18,
         )
-        self._put_text(
-            frame_bgr,
-            display_text,
-            panel_x + pad_x,
-            panel_y + pad_y + text_h,
-            scale=scale,
-            color=color,
-            thickness=thickness,
-            max_width=panel_w - (pad_x * 2),
-        )
+        text_y = panel_y + pad_y + text_h
+        for line in lines:
+            self._put_text(
+                frame_bgr,
+                line,
+                panel_x + pad_x,
+                text_y,
+                scale=scale,
+                color=color,
+                thickness=thickness,
+                max_width=None,
+            )
+            text_y += text_h + line_gap
 
     def _draw_pill(
         self,
@@ -1880,9 +1891,9 @@ class OverlayRenderer:
             alpha=0.9,
             radius=16,
         )
-        self._put_text(frame_bgr, label.upper(), x + 18, y + 28, 0.36, self.MUTED)
+        self._put_text(frame_bgr, label.upper(), x + 18, y + 28, 0.34, self.MUTED)
         self._put_text(
-            frame_bgr, value, x + 18, y + 58, 0.5, self.TEXT, max_width=width - 36
+            frame_bgr, value, x + 18, y + 58, 0.43, self.TEXT, max_width=width - 36
         )
 
     def _draw_action_card(
@@ -2322,6 +2333,56 @@ class OverlayRenderer:
             else:
                 high = mid - 1
         return text[:low].rstrip() + ellipsis
+
+    def _wrap_text(
+        self,
+        text: str,
+        max_width: int,
+        scale: float,
+        thickness: int,
+        *,
+        max_lines: int = 3,
+    ) -> list[str]:
+        if max_width <= 0:
+            return ["..."]
+
+        words = text.split()
+        if not words:
+            return [""]
+
+        lines: list[str] = []
+        current = ""
+        index = 0
+        while index < len(words):
+            word = words[index]
+            candidate = word if not current else f"{current} {word}"
+            if self._text_width(candidate, scale, thickness) <= max_width:
+                current = candidate
+                index += 1
+                continue
+
+            if current:
+                lines.append(current)
+                current = ""
+                if len(lines) >= max_lines:
+                    return lines[:max_lines]
+                continue
+
+            lines.append(self._fit_text(word, max_width, scale, thickness))
+            index += 1
+            if len(lines) >= max_lines:
+                return lines[:max_lines]
+
+        if current:
+            lines.append(current)
+
+        if len(lines) <= max_lines:
+            return lines
+
+        visible = lines[: max_lines - 1]
+        remaining = " ".join(lines[max_lines - 1 :])
+        visible.append(self._fit_text(remaining, max_width, scale, thickness))
+        return visible
 
     def _text_width(self, text: str, scale: float, thickness: int) -> int:
         font = self._load_font(self._font_size(scale), thickness > 1)

--- a/tests/test_squat_logic.py
+++ b/tests/test_squat_logic.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
-from analysis.squat import SquatRepCounter, SquatState, _angle_degrees
-from core.config import SquatConfig
+from analysis.squat import SquatRepCounter, SquatState, SquatStateAnalyzer, _angle_degrees
+from core.config import SQUAT_CONFIG, SquatConfig
 
 
-def _state(knee: float, ankle: float = 70.0, torso: float = 8.0) -> SquatState:
+def _state(
+    knee: float,
+    ankle: float = 70.0,
+    torso: float = 8.0,
+    quality_knee: float | None = None,
+) -> SquatState:
     if knee >= 160:
         label = "standing"
     elif knee <= 100:
@@ -21,6 +28,7 @@ def _state(knee: float, ankle: float = 70.0, torso: float = 8.0) -> SquatState:
         ankle_angle=ankle,
         torso_angle=torso,
         pose_visible=True,
+        quality_knee_angle=quality_knee,
     )
 
 
@@ -39,9 +47,67 @@ def _test_config() -> SquatConfig:
     )
 
 
+class _Landmark:
+    def __init__(self, x: float, y: float, visibility: float = 1.0) -> None:
+        self.x = x
+        self.y = y
+        self.visibility = visibility
+        self.presence = visibility
+
+
+class _PoseResult:
+    def __init__(self, landmarks) -> None:
+        self.pose_landmarks = [landmarks]
+
+
+def _blank_landmarks() -> list[_Landmark]:
+    return [_Landmark(0.0, 0.0, 0.0) for _ in range(33)]
+
+
+def _set_leg(
+    landmarks: list[_Landmark],
+    hip_i: int,
+    knee_i: int,
+    ankle_i: int,
+    angle: float,
+    visibility: float = 0.9,
+) -> None:
+    radians = math.radians(angle)
+    landmarks[hip_i] = _Landmark(1.0, 0.0, visibility)
+    landmarks[knee_i] = _Landmark(0.0, 0.0, visibility)
+    landmarks[ankle_i] = _Landmark(math.cos(radians), math.sin(radians), visibility)
+
+
 def test_angle_degrees_returns_angle_at_middle_point() -> None:
     assert _angle_degrees((1, 0), (0, 0), (0, 1)) == pytest.approx(90.0)
     assert _angle_degrees((1, 0), (0, 0), (1, 0)) == pytest.approx(0.0)
+
+
+def test_analyzer_uses_visible_side_instead_of_returning_no_pose() -> None:
+    landmarks = _blank_landmarks()
+    landmarks[24] = _Landmark(0.0, 0.0, 0.9)
+    landmarks[26] = _Landmark(0.0, 1.0, 0.9)
+    landmarks[28] = _Landmark(1.0, 1.0, 0.9)
+    landmarks[12] = _Landmark(0.0, -0.5, 0.9)
+
+    analyzer = SquatStateAnalyzer(_test_config())
+    state = analyzer.classify(_PoseResult(landmarks))
+
+    assert state.pose_visible is True
+    assert state.label == "down"
+    assert state.knee_angle == pytest.approx(90.0)
+
+
+def test_analyzer_keeps_conservative_quality_angle_for_back_view_noise() -> None:
+    landmarks = _blank_landmarks()
+    _set_leg(landmarks, 23, 25, 27, 90.0)
+    _set_leg(landmarks, 24, 26, 28, 130.0)
+
+    analyzer = SquatStateAnalyzer(_test_config())
+    state = analyzer.classify(_PoseResult(landmarks))
+
+    assert state.knee_angle == pytest.approx(90.0)
+    assert state.quality_knee_angle == pytest.approx(130.0)
 
 
 def test_rep_counter_counts_full_depth_rep_as_good() -> None:
@@ -84,6 +150,57 @@ def test_rep_counter_flags_shallow_rep_as_bad() -> None:
     assert "too_shallow" in complete.issues
     assert counter.rep_count == 1
     assert counter.bad_rep_count == 1
+
+
+def test_quality_knee_angle_flags_noisy_back_view_shallow_rep() -> None:
+    counter = SquatRepCounter(_test_config())
+
+    for timestamp, knee, quality in [
+        (0.0, 170, 170),
+        (0.1, 170, 170),
+        (0.2, 150, 150),
+        (0.3, 90, 130),
+        (0.4, 90, 130),
+        (0.5, 90, 130),
+    ]:
+        counter.update(_state(knee, quality_knee=quality), timestamp)
+    complete = counter.update(_state(170, quality_knee=170), 0.8)
+
+    assert complete.rep_completed is True
+    assert complete.is_bad is True
+    assert "too_shallow" in complete.issues
+    assert counter.rep_count == 1
+    assert counter.bad_rep_count == 1
+
+
+def test_default_ankle_threshold_does_not_warn_on_normal_ankle_angle() -> None:
+    counter = SquatRepCounter(SQUAT_CONFIG)
+
+    complete = None
+    timestamp = 0.0
+    for knee in [170, 170, 160, 150, 90, 90, 90, 90, 150, 160, 170, 170]:
+        update = counter.update(_state(knee, ankle=165.0), timestamp)
+        if update.rep_completed:
+            complete = update
+        timestamp += 0.1
+
+    assert complete is not None
+    assert "ankle_control" not in complete.issues
+
+
+def test_default_thresholds_count_full_and_shallow_validation_sets() -> None:
+    def run_reps(depths: list[float]) -> tuple[int, int]:
+        counter = SquatRepCounter(SQUAT_CONFIG)
+        timestamp = 0.0
+        for depth in depths:
+            for knee in [170, 170, 160, 150, depth, depth, depth, depth, 150, 160, 170, 170]:
+                counter.update(_state(knee), timestamp)
+                timestamp += 0.08
+        return counter.rep_count, counter.bad_rep_count
+
+    assert run_reps([90.0] * 10) == (10, 0)
+    assert run_reps([130.0] * 5) == (5, 5)
+    assert run_reps(([90.0] * 5) + ([130.0] * 5)) == (10, 5)
 
 
 def test_no_pose_resets_incomplete_cycle_before_counting() -> None:


### PR DESCRIPTION
Closes #58 

## What changed
- Improved squat detection stability for front-facing and slight side-facing positions.
- Made landmark/side selection more defensive when one side is less visible.
- Fixed shallow squat classification so bad reps increment correctly.
- Preserved separation between rep detection and form-quality evaluation.
- Fixed UI overlap/readability issues in live overlay and dashboard screens.

## How to run/test
python src/app.py

## Test steps
- Run 10 full-depth squats and confirm app count matches manual count with bad reps = 0.
- Run 5 shallow squats and confirm app count = 5 and bad reps = 5.
- Run 5 full + 5 shallow squats and confirm app count = 10 and bad reps = 5.
- Turn slightly left and right and confirm the app does not immediately fail to no_pose when landmarks are visible.
- Check live overlay, analytics dashboard, and session browser for overlapping or clipped text.

## Evidence
- Final manual testing should confirm corrected rep counting, shallow squat classification, and readable UI.