### PR TITLE
feat: add offline local video analysis mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ assets/models/*.task
 sessions/
 user_data/
 exports/
+input_videos/

--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -338,6 +338,10 @@ class SquatRepCounter:
         self._min_ankle_angle: Optional[float] = None
         self._max_torso_angle: Optional[float] = None
 
+    @property
+    def in_rep(self) -> bool:
+        return self._in_rep
+
     def update(self, squat_state: SquatState, timestamp: float) -> RepCounterUpdate:
         if squat_state.label == "no_pose" or not squat_state.pose_visible:
             return self._handle_missing_pose()

--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from analysis.squat import SquatRepCounter, SquatStateAnalyzer
 from core.config import CALIBRATION_CONFIG, SquatConfig
-from core.paths import SESSIONS_DIR
+from core.paths import INPUT_VIDEOS_DIR, SESSIONS_DIR
 from core.user_profile import (
     build_calibration_profile,
     load_app_settings,
@@ -36,8 +36,10 @@ from session.browser import (
     open_session_video,
 )
 from session.analytics_export import export_analytics_report
+from session.feedback import current_feedback, rep_feedback
 from session.recorder import SessionRecorder
 from session.summary import SessionSummary
+from session.video_analysis import analyze_video_file, find_latest_input_video
 from ui.overlay import OverlayRenderer
 
 
@@ -51,9 +53,11 @@ STATE_BROWSE = "browse"
 STATE_ANALYTICS = "analytics"
 STATE_CALIBRATION = "calibration"
 STATE_SETTINGS = "settings"
+STATE_VIDEO_ANALYSIS = "video_analysis"
 UP_KEY = 2490368
 DOWN_KEY = 2621440
 FEEDBACK_HOLD_SECONDS = 2.0
+NOTICE_HOLD_SECONDS = 10.0
 SW_MAXIMIZE = 3
 STATIC_SCREEN_WAIT_MS = 80
 CAMERA_INDICES = (0, 1, 2)
@@ -65,11 +69,28 @@ FALLBACK_CAMERA_LABELS = {
 
 _WINDOW_MAXIMIZED = False
 _LAST_CAMERA_WARNING: str | None = None
+_LAST_CAMERA_WARNING_AT = 0.0
 
 
 def _sync_app_background(overlay: OverlayRenderer) -> None:
     global APP_BG
     APP_BG = overlay.BG
+
+
+def _set_dashboard_notice(message: str | None) -> None:
+    global _LAST_CAMERA_WARNING, _LAST_CAMERA_WARNING_AT
+    _LAST_CAMERA_WARNING = message
+    _LAST_CAMERA_WARNING_AT = time.monotonic() if message else 0.0
+
+
+def _get_dashboard_notice() -> str | None:
+    global _LAST_CAMERA_WARNING, _LAST_CAMERA_WARNING_AT
+    if not _LAST_CAMERA_WARNING:
+        return None
+    if time.monotonic() - _LAST_CAMERA_WARNING_AT > NOTICE_HOLD_SECONDS:
+        _set_dashboard_notice(None)
+        return None
+    return _LAST_CAMERA_WARNING
 
 
 def _get_window_client_size(window_name: str) -> tuple[int, int] | None:
@@ -212,30 +233,21 @@ def _current_feedback(
     feedback_until: float,
     timestamp: float,
     squat_config: SquatConfig,
+    is_in_rep: bool = False,
 ) -> tuple[str | None, str]:
-    if feedback_message and timestamp <= feedback_until:
-        return feedback_message, feedback_level
-
-    angle = squat_state.knee_angle
-    if (
-        angle is not None
-        and squat_config.shallow_knee_angle < angle <= squat_config.rep_bottom_knee_angle
-    ):
-        return "Go deeper", "warning"
-
-    return None, "info"
+    return current_feedback(
+        squat_state,
+        feedback_message,
+        feedback_level,
+        feedback_until,
+        timestamp,
+        squat_config,
+        is_in_rep=is_in_rep,
+    )
 
 
 def _rep_feedback(issues: tuple[str, ...], is_bad: bool) -> tuple[str, str]:
-    if is_bad and "too_shallow" in issues:
-        return "Bad rep: lower hips and bend knees more", "bad"
-    if "torso_lean" in issues and "ankle_control" in issues:
-        return "Rep logged: feet flat, knees over toes, chest up", "warning"
-    if "torso_lean" in issues:
-        return "Rep logged: brace core and keep chest up", "warning"
-    if "ankle_control" in issues:
-        return "Rep logged: keep feet flat; knees track over toes", "warning"
-    return "Rep accepted", "ok"
+    return rep_feedback(issues, is_bad)
 
 
 def _filter_sessions_for_settings(sessions, settings):
@@ -348,8 +360,6 @@ def _camera_has_frame(cap: cv2.VideoCapture) -> bool:
 
 def _open_camera(camera_index: int, context: str) -> tuple[cv2.VideoCapture | None, int]:
     """Open the selected camera index, falling back to index 0 when needed."""
-    global _LAST_CAMERA_WARNING
-
     requested_index = camera_index if 0 <= camera_index <= 2 else 0
     indices = [requested_index]
     if requested_index != 0:
@@ -370,20 +380,21 @@ def _open_camera(camera_index: int, context: str) -> tuple[cv2.VideoCapture | No
                     f"{context}; using camera 0 instead."
                 )
                 print(warning)
-                _LAST_CAMERA_WARNING = warning
+                _set_dashboard_notice(warning)
                 set_camera_index(load_app_settings(), 0)
             else:
-                _LAST_CAMERA_WARNING = None
+                _set_dashboard_notice(None)
             return cap, index
 
         cap.release()
         print(f"Warning: camera {index} could not be opened for {context}.")
 
-    _LAST_CAMERA_WARNING = (
+    warning = (
         f"Warning: camera {requested_index} could not be opened for {context}, "
         "and fallback camera 0 also failed."
     )
-    print(_LAST_CAMERA_WARNING)
+    _set_dashboard_notice(warning)
+    print(warning)
     return None, requested_index
 
 
@@ -486,6 +497,7 @@ def run_session(overlay: OverlayRenderer) -> bool:
                 feedback_until,
                 timestamp,
                 squat_config,
+                is_in_rep=rep_counter.in_rep,
             )
             overlay.draw(
                 frame,
@@ -628,6 +640,33 @@ def run_analytics(overlay: OverlayRenderer) -> bool:
                 os.startfile(str(report_path))
             except (AttributeError, OSError) as exc:
                 print(f"Warning: could not open analytics report: {exc}")
+
+
+def run_video_analysis(overlay: OverlayRenderer) -> bool:
+    """Analyse the newest local video in input_videos using the live pipeline."""
+    video_path = find_latest_input_video(INPUT_VIDEOS_DIR)
+    if video_path is None:
+        notice = (
+            "No videos found in input_videos. Add an MP4/AVI/MOV/MKV file, then press V."
+        )
+        _set_dashboard_notice(notice)
+        print(notice)
+        return _window_is_open(WINDOW_NAME)
+
+    print(f"Analysing local video: {video_path}")
+    result = analyze_video_file(
+        video_path,
+        overlay,
+        show_frame=lambda frame: _show_frame(WINDOW_NAME, frame),
+        poll_key=_wait_for_key_or_close,
+    )
+    _set_dashboard_notice(result.message)
+    print(result.message)
+    if result.summary_path:
+        print(f"Video analysis summary saved: {result.summary_path}")
+    if result.analysed_video_path:
+        print(f"Analysed video saved: {result.analysed_video_path}")
+    return result.keep_running and _window_is_open(WINDOW_NAME)
 
 
 def run_calibration(overlay: OverlayRenderer) -> bool:
@@ -783,8 +822,6 @@ def run_settings(overlay: OverlayRenderer) -> bool:
 
 
 def main() -> None:
-    global _LAST_CAMERA_WARNING
-
     settings = load_app_settings()
     overlay = OverlayRenderer(settings.theme)
     _sync_app_background(overlay)
@@ -803,7 +840,7 @@ def main() -> None:
                     frame,
                     load_calibration_profile(),
                     settings,
-                    _LAST_CAMERA_WARNING,
+                    _get_dashboard_notice(),
                     _camera_options(),
                 )
                 _show_frame(WINDOW_NAME, frame)
@@ -815,6 +852,8 @@ def main() -> None:
                     continue
                 if key in (ord("s"), ord("S")):
                     state = STATE_SESSION
+                elif key in (ord("v"), ord("V")):
+                    state = STATE_VIDEO_ANALYSIS
                 elif key in (ord("c"), ord("C")):
                     state = STATE_CALIBRATION
                 elif key in (ord("b"), ord("B")):
@@ -826,11 +865,15 @@ def main() -> None:
                 elif key in (ord("k"), ord("K")):
                     _windows_camera_names.cache_clear()
                     settings = switch_camera_index(settings)
-                    _LAST_CAMERA_WARNING = None
+                    _set_dashboard_notice(None)
                 elif key == 27:
                     break
             elif state == STATE_SESSION:
                 if not run_session(overlay):
+                    break
+                state = STATE_DASHBOARD
+            elif state == STATE_VIDEO_ANALYSIS:
+                if not run_video_analysis(overlay):
                     break
                 state = STATE_DASHBOARD
             elif state == STATE_BROWSE:

--- a/src/core/paths.py
+++ b/src/core/paths.py
@@ -7,6 +7,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 SESSIONS_DIR = PROJECT_ROOT / "sessions"
+INPUT_VIDEOS_DIR = PROJECT_ROOT / "input_videos"
 
 ASSETS_DIR = PROJECT_ROOT / "assets"
 MODELS_DIR = ASSETS_DIR / "models"

--- a/src/pose/detector.py
+++ b/src/pose/detector.py
@@ -33,15 +33,18 @@ class PoseDetector:
         self._landmarker = vision.PoseLandmarker.create_from_options(options)
         self._timestamp_ms = 0  # must increase for VIDEO mode
 
-    def process(self, frame_bgr):
+    def process(self, frame_bgr, timestamp_ms: int | None = None):
         """Run pose detection on a BGR frame and return a PoseLandmarkerResult."""
         frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
 
         # ✅ In this MediaPipe build, Image is at top-level mediapipe.Image
         mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=frame_rgb)
 
-        # VIDEO mode requires monotonically increasing timestamps
-        self._timestamp_ms += 33  # ~30fps
+        # VIDEO mode requires monotonically increasing timestamps.
+        if timestamp_ms is None:
+            self._timestamp_ms += 33  # ~30fps fallback for live webcam frames.
+        else:
+            self._timestamp_ms = max(int(timestamp_ms), self._timestamp_ms + 1)
         return self._landmarker.detect_for_video(mp_image, self._timestamp_ms)
 
     def close(self) -> None:

--- a/src/session/analytics_export.py
+++ b/src/session/analytics_export.py
@@ -121,6 +121,12 @@ def _build_html(snapshot: AnalyticsSnapshot, calibration_profile=None) -> str:
       font-size: 30px;
       font-weight: 800;
       letter-spacing: -0.03em;
+      line-height: 1.15;
+      overflow-wrap: anywhere;
+    }}
+    .metric-value.long {{
+      font-size: 24px;
+      letter-spacing: -0.02em;
     }}
     .section {{
       margin-top: 18px;
@@ -227,10 +233,14 @@ def _build_html(snapshot: AnalyticsSnapshot, calibration_profile=None) -> str:
 
 
 def _metric_card(label: str, value, css_class: str = "") -> str:
+    value_text = str(value)
+    value_classes = " ".join(
+        part for part in (css_class, "long" if len(value_text) > 18 else "") if part
+    )
     return (
         '<article class="card">'
         f'<div class="metric-label">{escape(str(label))}</div>'
-        f'<div class="metric-value {escape(css_class)}">{escape(str(value))}</div>'
+        f'<div class="metric-value {escape(value_classes)}">{escape(value_text)}</div>'
         "</article>"
     )
 
@@ -315,11 +325,19 @@ def _format_issue(value: str | None) -> str:
 def _format_timestamp(value: str | None) -> str:
     if not value:
         return "N/A"
+    prefix = ""
+    suffix = ""
+    if value.startswith("video_"):
+        prefix = "Video "
+        value = value[len("video_") :]
+        if len(value) > 15 and value[15] == "_":
+            suffix = f" #{value[16:]}"
+            value = value[:15]
     if len(value) == 15 and "_" in value:
         date_part, time_part = value.split("_", maxsplit=1)
         if len(date_part) == 8 and len(time_part) == 6:
             return (
-                f"{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
-                f"{time_part[0:2]}:{time_part[2:4]}:{time_part[4:6]}"
+                f"{prefix}{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
+                f"{time_part[0:2]}:{time_part[2:4]}:{time_part[4:6]}{suffix}"
             )
-    return value
+    return f"{prefix}{value}{suffix}"

--- a/src/session/browser.py
+++ b/src/session/browser.py
@@ -93,14 +93,14 @@ def list_recent_sessions(
         return []
 
     folders = [path for path in sessions_dir.iterdir() if path.is_dir()]
-    folders.sort(key=lambda path: path.name, reverse=True)
+    folders.sort(key=_session_sort_key, reverse=True)
     if limit is not None:
         folders = folders[:limit]
 
     items: list[SessionBrowserItem] = []
     for folder in folders:
         summary_path = folder / "summary.json"
-        video_path = folder / "session.mp4"
+        video_path = _session_video_path(folder)
         data = _load_summary_data(summary_path)
         rep_count = _safe_int(data.get("rep_count")) if data else None
         bad_rep_count = _safe_int(data.get("bad_rep_count")) if data else None
@@ -218,6 +218,27 @@ def open_session_folder(session: SessionBrowserItem) -> None:
         return
 
     os.startfile(str(session.folder_path))
+
+
+def _session_video_path(folder: Path) -> Path:
+    live_video_path = folder / "session.mp4"
+    if live_video_path.exists():
+        return live_video_path
+    analysed_video_path = folder / "analysed_video.mp4"
+    if analysed_video_path.exists():
+        return analysed_video_path
+    return live_video_path
+
+
+def _session_sort_key(path: Path) -> str:
+    name = path.name
+    if name.startswith("video_"):
+        candidate = name.removeprefix("video_")
+        if len(candidate) >= 15:
+            return candidate[:15]
+    if len(name) >= 15:
+        return name[:15]
+    return name
 
 
 def _load_summary_data(summary_path: Path) -> Optional[dict]:

--- a/src/session/feedback.py
+++ b/src/session/feedback.py
@@ -1,0 +1,41 @@
+"""Shared live-feedback wording for rep results and in-progress cues."""
+
+from __future__ import annotations
+
+from core.config import SquatConfig
+
+
+def current_feedback(
+    squat_state,
+    feedback_message: str | None,
+    feedback_level: str,
+    feedback_until: float,
+    timestamp: float,
+    squat_config: SquatConfig,
+    *,
+    is_in_rep: bool = False,
+) -> tuple[str | None, str]:
+    if feedback_message and timestamp <= feedback_until:
+        return feedback_message, feedback_level
+
+    angle = squat_state.knee_angle
+    if (
+        not is_in_rep
+        and angle is not None
+        and squat_config.shallow_knee_angle < angle <= squat_config.rep_bottom_knee_angle
+    ):
+        return "Go deeper", "warning"
+
+    return None, "info"
+
+
+def rep_feedback(issues: tuple[str, ...], is_bad: bool) -> tuple[str, str]:
+    if is_bad and "too_shallow" in issues:
+        return "Bad rep: lower hips and bend knees more", "bad"
+    if "torso_lean" in issues and "ankle_control" in issues:
+        return "Rep logged: feet flat, knees over toes, chest up", "warning"
+    if "torso_lean" in issues:
+        return "Rep logged: brace core and keep chest up", "warning"
+    if "ankle_control" in issues:
+        return "Rep logged: keep feet flat; knees track over toes", "warning"
+    return "Rep accepted", "ok"

--- a/src/session/recorder.py
+++ b/src/session/recorder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import time
 from typing import Optional
 
 import cv2
@@ -15,11 +16,17 @@ class SessionRecorder:
         self.output_dir = output_dir
         self.output_path = output_dir / "session.mp4"
         self._writer: Optional[cv2.VideoWriter] = None
+        self._fps = 30.0
+        self._started_at: float | None = None
+        self._written_frames = 0
         self.enabled = False
 
     def start(self, frame_size: tuple[int, int], fps: float) -> None:
         self.output_dir.mkdir(parents=True, exist_ok=True)
-        safe_fps = fps if fps and fps > 1 else 30.0
+        safe_fps = float(fps) if fps and 5 <= fps <= 60 else 30.0
+        self._fps = float(safe_fps)
+        self._started_at = None
+        self._written_frames = 0
         writer = cv2.VideoWriter(
             str(self.output_path),
             cv2.VideoWriter_fourcc(*"mp4v"),
@@ -35,11 +42,23 @@ class SessionRecorder:
         self.enabled = True
 
     def write(self, frame) -> None:
-        if self.enabled and self._writer is not None:
+        if not self.enabled or self._writer is None:
+            return
+
+        now = time.monotonic()
+        if self._started_at is None:
+            self._started_at = now
+
+        elapsed = max(0.0, now - self._started_at)
+        expected_frames = max(1, int(elapsed * self._fps) + 1)
+        while self._written_frames < expected_frames:
             self._writer.write(frame)
+            self._written_frames += 1
 
     def stop(self) -> None:
         if self._writer is not None:
             self._writer.release()
             self._writer = None
+        self._started_at = None
+        self._written_frames = 0
         self.enabled = False

--- a/src/session/video_analysis.py
+++ b/src/session/video_analysis.py
@@ -1,0 +1,238 @@
+"""Offline local-video analysis using the live squat-analysis pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import time
+from typing import Callable
+
+import cv2
+
+from analysis.squat import SquatRepCounter, SquatStateAnalyzer
+from core.paths import INPUT_VIDEOS_DIR, SESSIONS_DIR
+from core.user_profile import load_calibration_profile, load_squat_config
+from pose.detector import PoseDetector
+from session.feedback import current_feedback, rep_feedback
+from session.summary import SessionSummary
+from ui.overlay import OverlayRenderer
+
+
+SUPPORTED_VIDEO_EXTENSIONS = (".mp4", ".avi", ".mov", ".mkv", ".m4v")
+FEEDBACK_HOLD_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class VideoAnalysisResult:
+    success: bool
+    message: str
+    keep_running: bool = True
+    source_video_path: Path | None = None
+    session_dir: Path | None = None
+    summary_path: Path | None = None
+    analysed_video_path: Path | None = None
+
+
+def find_latest_input_video(input_dir: Path = INPUT_VIDEOS_DIR) -> Path | None:
+    """Return the newest supported video in the local input folder."""
+    input_dir.mkdir(parents=True, exist_ok=True)
+    videos = [
+        path
+        for path in input_dir.iterdir()
+        if path.is_file() and path.suffix.lower() in SUPPORTED_VIDEO_EXTENSIONS
+    ]
+    if not videos:
+        return None
+    return max(videos, key=lambda path: (path.stat().st_mtime, path.name.lower()))
+
+
+def analyze_video_file(
+    video_path: Path,
+    overlay: OverlayRenderer,
+    *,
+    show_frame: Callable[[object], None],
+    poll_key: Callable[[int], int | None],
+) -> VideoAnalysisResult:
+    """Process a local video and save annotated evidence under sessions/video_*."""
+    if not video_path.exists():
+        return VideoAnalysisResult(
+            success=False,
+            message=f"Video not found: {video_path}",
+            source_video_path=video_path,
+        )
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        cap.release()
+        return VideoAnalysisResult(
+            success=False,
+            message=f"Could not open video: {video_path.name}",
+            source_video_path=video_path,
+        )
+
+    source_fps = cap.get(cv2.CAP_PROP_FPS)
+    fps = source_fps if source_fps and source_fps > 1 else 30.0
+    frame_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    frame_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    if frame_w <= 0 or frame_h <= 0:
+        ok, sample = cap.read()
+        if not ok:
+            cap.release()
+            return VideoAnalysisResult(
+                success=False,
+                message=f"No readable frames in video: {video_path.name}",
+                source_video_path=video_path,
+            )
+        frame_h, frame_w = sample.shape[:2]
+        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+
+    started_at = datetime.now()
+    session_dir = _unique_video_session_dir(started_at)
+    analysed_video_path = session_dir / "analysed_video.mp4"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    writer = cv2.VideoWriter(
+        str(analysed_video_path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        fps,
+        (frame_w, frame_h),
+    )
+    writer_enabled = writer.isOpened()
+    if not writer_enabled:
+        print("Warning: failed to initialize analysed video writer. Summary will still be saved.")
+
+    detector = PoseDetector()
+    calibration_profile = load_calibration_profile()
+    squat_config = (
+        calibration_profile.to_squat_config()
+        if calibration_profile is not None
+        else load_squat_config()
+    )
+    analyzer = SquatStateAnalyzer(squat_config)
+    rep_counter = SquatRepCounter(squat_config)
+    summary = SessionSummary(started_at=started_at)
+    feedback_message: str | None = None
+    feedback_level = "info"
+    feedback_until = 0.0
+    frame_index = 0
+    previous_processing_time = 0.0
+    processing_fps = 0.0
+    keep_running = True
+    cancelled = False
+
+    try:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+
+            frame_time = frame_index / fps
+            processing_now = time.time()
+            if previous_processing_time > 0:
+                delta = processing_now - previous_processing_time
+                if delta > 0:
+                    instant_fps = 1.0 / delta
+                    processing_fps = (
+                        instant_fps
+                        if processing_fps == 0
+                        else (0.9 * processing_fps + 0.1 * instant_fps)
+                    )
+            previous_processing_time = processing_now
+            summary.add_fps_sample(processing_fps)
+
+            timestamp_ms = int(frame_time * 1000)
+            results = detector.process(frame, timestamp_ms=timestamp_ms)
+            squat_state = analyzer.classify(results)
+            rep_update = rep_counter.update(squat_state, frame_time)
+
+            summary.add_pose_metrics(
+                knee_angle=squat_state.knee_angle,
+                ankle_angle=squat_state.ankle_angle,
+                torso_angle=squat_state.torso_angle,
+            )
+
+            if rep_update.rep_started:
+                summary.record_rep_start(frame_time)
+            if rep_update.rep_completed:
+                summary.record_rep_complete(frame_time, reason=rep_update.reason)
+                summary.record_completed_rep(
+                    rep_index=rep_counter.rep_count,
+                    timestamp=frame_time,
+                    is_bad=rep_update.is_bad,
+                    issues=rep_update.issues,
+                    min_knee_angle=rep_update.min_knee_angle,
+                    min_ankle_angle=rep_update.min_ankle_angle,
+                    max_torso_angle=rep_update.max_torso_angle,
+                )
+                summary.record_issues(rep_update.issues)
+                feedback_message, feedback_level = rep_feedback(
+                    rep_update.issues,
+                    rep_update.is_bad,
+                )
+                feedback_until = frame_time + FEEDBACK_HOLD_SECONDS
+
+            summary.rep_count = rep_counter.rep_count
+            summary.bad_rep_count = rep_counter.bad_rep_count
+
+            feedback_text, feedback_kind = current_feedback(
+                squat_state,
+                feedback_message,
+                feedback_level,
+                feedback_until,
+                frame_time,
+                squat_config,
+                is_in_rep=rep_counter.in_rep,
+            )
+            overlay.draw(
+                frame,
+                results,
+                squat_state,
+                rep_counter,
+                feedback_text,
+                feedback_kind,
+                calibration_profile,
+            )
+
+            if writer_enabled:
+                writer.write(frame)
+            show_frame(frame)
+
+            key = poll_key(1)
+            if key is None:
+                keep_running = False
+                break
+            if key == 27:
+                cancelled = True
+                break
+
+            frame_index += 1
+    finally:
+        summary.rep_count = rep_counter.rep_count
+        summary.bad_rep_count = rep_counter.bad_rep_count
+        summary_path = summary.save(session_dir)
+        if writer_enabled:
+            writer.release()
+        detector.close()
+        cap.release()
+
+    prefix = "Video analysis cancelled and saved" if cancelled else "Video analysis saved"
+    return VideoAnalysisResult(
+        success=True,
+        message=f"{prefix}: {session_dir.name}",
+        keep_running=keep_running,
+        source_video_path=video_path,
+        session_dir=session_dir,
+        summary_path=summary_path,
+        analysed_video_path=analysed_video_path if writer_enabled else None,
+    )
+
+
+def _unique_video_session_dir(started_at: datetime) -> Path:
+    base_name = f"video_{started_at.strftime('%Y%m%d_%H%M%S')}"
+    session_dir = SESSIONS_DIR / base_name
+    suffix = 1
+    while session_dir.exists():
+        session_dir = SESSIONS_DIR / f"{base_name}_{suffix}"
+        suffix += 1
+    return session_dir

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -18,23 +18,23 @@ class OverlayRenderer:
     FONT_BOLD = Path(r"C:\Windows\Fonts\segoeuib.ttf")
 
     # Shared visual system. OpenCV uses BGR tuples.
-    BG = (229, 237, 233)
-    BG_SOFT = (218, 231, 225)
-    PANEL = (252, 253, 251)
-    PANEL_ALT = (237, 244, 240)
-    PANEL_STRONG = (221, 238, 229)
-    SELECTED = (199, 229, 213)
-    BORDER = (164, 187, 176)
-    BORDER_ACTIVE = (76, 145, 91)
+    BG = (239, 247, 242)
+    BG_SOFT = (250, 253, 250)
+    PANEL = (255, 255, 255)
+    PANEL_ALT = (248, 251, 249)
+    PANEL_STRONG = (229, 243, 234)
+    SELECTED = (212, 236, 219)
+    BORDER = (193, 211, 198)
+    BORDER_ACTIVE = (74, 142, 86)
 
-    PRIMARY = (54, 126, 72)
-    PRIMARY_SOFT = (191, 224, 205)
+    PRIMARY = (45, 119, 67)
+    PRIMARY_SOFT = (218, 239, 224)
     WARNING = (0, 143, 204)
     ERROR = (76, 86, 205)
     INFO = (196, 127, 66)
-    TEXT = (25, 35, 32)
-    MUTED = (76, 91, 86)
-    MUTED_DARK = (124, 139, 133)
+    TEXT = (28, 47, 38)
+    MUTED = (88, 108, 99)
+    MUTED_DARK = (138, 152, 145)
     LIVE_PANEL = (36, 47, 49)
     LIVE_CARD = (48, 60, 62)
     LIVE_BORDER = (102, 218, 150)
@@ -223,18 +223,18 @@ class OverlayRenderer:
 
         options = [
             ("S", "Start squat session", "Open webcam and begin form tracking"),
+            ("V", "Analyse local video", "Process newest file in input_videos"),
             ("C", "Calibrate squat depth", "Personalise thresholds with 2-3 squats"),
             ("A", "Open analytics dashboard", "View progress and recommendations"),
             ("B", "Browse saved sessions", "Review videos and session files"),
             ("G", "Open settings", "Theme, calibration, and browser display"),
-            ("Esc", "Quit application", "Close GymGuardian"),
         ]
 
-        card_gap = 14
+        card_gap = 10
         cards_x = shell_x + 58
-        cards_y = shell_y + 238
+        cards_y = shell_y + 248
         card_w = (shell_w - 116 - card_gap) // 2
-        card_h = 76
+        card_h = 64
         for index, (key, title, subtitle) in enumerate(options):
             col = index % 2
             row = index // 2
@@ -254,7 +254,7 @@ class OverlayRenderer:
                 frame_bgr,
                 notice_message,
                 shell_x + 62,
-                shell_y + shell_h - 58,
+                shell_y + 224,
                 scale=0.42,
                 color=self.WARNING,
                 thickness=1,
@@ -263,7 +263,7 @@ class OverlayRenderer:
 
         self._put_text(
             frame_bgr,
-            "Keyboard controlled desktop prototype. K switches camera source. Esc returns from any screen.",
+            "Keyboard desktop prototype. V analyses videos. K switches camera. Esc quits/returns.",
             shell_x + 62,
             shell_y + shell_h - 34,
             scale=0.47,
@@ -914,9 +914,9 @@ class OverlayRenderer:
             else "Showing all sessions"
         )
         calibration_value = (
-            "Adaptive thresholds active"
+            "Calibrated"
             if calibration_profile
-            else "Default thresholds active"
+            else "Default thresholds"
         )
         cards = [
             ("Theme", theme_value, "Press T to switch light/dark", self.PRIMARY),
@@ -1307,8 +1307,8 @@ class OverlayRenderer:
 
         card_gap = 10
         card_w = (width - 48 - (card_gap * 2)) // 3
-        card_y = y + 76 if compact else y + 92
-        card_h = 44 if compact else 68
+        card_y = y + 72 if compact else y + 92
+        card_h = 36 if compact else 68
         self._draw_metric_tile(
             frame_bgr,
             x + 24,
@@ -1319,7 +1319,7 @@ class OverlayRenderer:
             self._format_change(snapshot.rep_count_change),
             self._change_color(snapshot.rep_count_change, positive_is_good=True),
             label_scale=0.34 if compact else 0.42,
-            value_scale=0.42 if compact else 0.64,
+            value_scale=0.36 if compact else 0.64,
         )
         self._draw_metric_tile(
             frame_bgr,
@@ -1333,7 +1333,7 @@ class OverlayRenderer:
                 snapshot.bad_rep_percentage_change, positive_is_good=False
             ),
             label_scale=0.34 if compact else 0.42,
-            value_scale=0.34 if compact else 0.52,
+            value_scale=0.31 if compact else 0.52,
         )
         self._draw_metric_tile(
             frame_bgr,
@@ -1345,7 +1345,7 @@ class OverlayRenderer:
             self._format_angle_change(snapshot.avg_knee_angle_change),
             self.TEXT,
             label_scale=0.34 if compact else 0.42,
-            value_scale=0.34 if compact else 0.52,
+            value_scale=0.31 if compact else 0.52,
         )
 
         if not compact:
@@ -1465,9 +1465,14 @@ class OverlayRenderer:
         text = "Calibrated" if is_calibrated else "Default thresholds"
 
         if is_calibrated:
-            fill = (43, 58, 24)
-            border = (73, 110, 44)
-            text_color = self.PRIMARY if not live else self.LIVE_BORDER
+            if live or self.theme == "dark":
+                fill = (43, 58, 24)
+                border = (73, 110, 44)
+                text_color = self.LIVE_BORDER if live else self.PRIMARY
+            else:
+                fill = self.PRIMARY_SOFT
+                border = self.BORDER_ACTIVE
+                text_color = self.PRIMARY
         else:
             fill = self.LIVE_CARD if live else self.PANEL_ALT
             border = self.BORDER if not live else (78, 94, 98)
@@ -2106,14 +2111,14 @@ class OverlayRenderer:
             glow_alpha = 0.26
             footer_color = (68, 78, 32)
         else:
-            texture_color = (211, 224, 218)
-            texture_alpha = 0.24
-            header_color = (221, 234, 228)
-            header_border = (175, 198, 187)
-            glow_primary = (188, 222, 204)
-            glow_secondary = (217, 226, 229)
-            glow_alpha = 0.32
-            footer_color = (184, 215, 199)
+            texture_color = (231, 239, 234)
+            texture_alpha = 0.14
+            header_color = (248, 252, 249)
+            header_border = (199, 215, 203)
+            glow_primary = (224, 243, 230)
+            glow_secondary = (238, 245, 241)
+            glow_alpha = 0.24
+            footer_color = (206, 226, 213)
 
         texture = frame_bgr.copy()
         for x in range(-frame_h, frame_w, 92):
@@ -2144,6 +2149,21 @@ class OverlayRenderer:
     ) -> None:
         color = self.PANEL if color is None else color
         border_color = self.BORDER if border_color is None else border_color
+        is_live_panel = color in (self.LIVE_PANEL, self.LIVE_CARD)
+        if self.theme == "light" and not is_live_panel and width >= 180 and height >= 54:
+            shadow = frame_bgr.copy()
+            self._draw_rounded_rect(
+                shadow,
+                x + 4,
+                y + 6,
+                width,
+                height,
+                radius,
+                (178, 199, 185),
+                -1,
+            )
+            cv2.addWeighted(shadow, 0.10, frame_bgr, 0.90, 0, frame_bgr)
+
         overlay = frame_bgr.copy()
         self._draw_rounded_rect(overlay, x, y, width, height, radius, color, -1)
         cv2.addWeighted(overlay, alpha, frame_bgr, 1 - alpha, 0, frame_bgr)
@@ -2550,19 +2570,25 @@ class OverlayRenderer:
     def _format_session_timestamp(value: str | None) -> str:
         if not value:
             return "N/A"
+        prefix = ""
+        if value.startswith("video_"):
+            prefix = "Video "
+            value = value[len("video_") :]
         if len(value) == 15 and "_" in value:
             date_part, time_part = value.split("_", maxsplit=1)
             if len(date_part) == 8 and len(time_part) == 6:
                 return (
-                    f"{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
+                    f"{prefix}{date_part[0:4]}-{date_part[4:6]}-{date_part[6:8]} "
                     f"{time_part[0:2]}:{time_part[2:4]}:{time_part[4:6]}"
                 )
-        return value
+        return f"{prefix}{value}"
 
     @staticmethod
     def _format_short_session_timestamp(value: str | None) -> str:
         if not value:
             return "N/A"
+        if value.startswith("video_"):
+            value = value[len("video_") :]
         if len(value) == 15 and "_" in value:
             date_part, time_part = value.split("_", maxsplit=1)
             if len(date_part) == 8 and len(time_part) == 6:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -79,3 +79,15 @@ def test_session_browser_marks_incomplete_sessions_without_crashing(tmp_path) ->
     assert sessions[0].folder_name.endswith("(incomplete)")
     assert sessions[1].valid_session is True
     assert sessions[1].folder_name == "20260502_120000"
+
+
+def test_session_browser_supports_video_analysis_folders(tmp_path) -> None:
+    _write_summary(tmp_path, "20260503_120000", {"rep_count": 4, "bad_rep_count": 0})
+    _write_summary(tmp_path, "video_20260504_120000", {"rep_count": 5, "bad_rep_count": 1})
+    analysed_video = tmp_path / "video_20260504_120000" / "analysed_video.mp4"
+    analysed_video.write_bytes(b"placeholder")
+
+    sessions = list_recent_sessions(tmp_path, limit=None)
+
+    assert sessions[0].folder_name == "video_20260504_120000"
+    assert sessions[0].video_path == analysed_video


### PR DESCRIPTION
Closes #60 

## What changed
- Added offline local video analysis mode for prerecorded squat videos.
- Reused the existing pose detection, squat analysis, rep counting, bad rep detection, and summary pipeline.
- Added annotated output video generation.
- Saved analysed outputs under sessions/video_<timestamp>/.
- Added dashboard access for local video analysis.
- Preserved the existing live webcam session workflow.

## How to run/test
python src/app.py

## Test steps
- Place a squat video inside input_videos/.
- Launch the app.
- Select the local video analysis option from the dashboard.
- Confirm the video is processed without requiring webcam input.
- Confirm sessions/video_<timestamp>/ is created.
- Confirm summary.json is generated.
- Confirm analysed_video.mp4 is generated and includes overlay.
- Confirm live webcam session still works after this change.

## Evidence
- Local prerecorded videos can now be analysed using the same squat-analysis pipeline as live webcam sessions.