### PR TITLE
feat: bad-rep evidence export with slow-motion clips and chapter markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ __pycache__/
 venv/
 env/
 
+# Local executable builds
+build/
+dist/
+*.spec
+
 # IDE / Editor
 .vscode/
 .idea/
@@ -19,6 +24,13 @@ Thumbs.db
 
 # Jupyter
 .ipynb_checkpoints/
+
+# Local report extraction/cache artefacts
+docs/_extracted/
+docs/__pycache__/
+
+# Local coursework evidence workbooks generated outside the app
+GymGuardian_Test_Cases.xlsx
 
 # Models & data (can be large)
 models/*.h5

--- a/README.md
+++ b/README.md
@@ -13,45 +13,56 @@ GymGuardian is treated as a specialized squat-coaching prototype rather than a g
 
 Multi-exercise support is considered future work.
 
-## Current Features
+## Features
 
 - real-time pose detection using MediaPipe and OpenCV
 - squat state classification with smoothed joint-angle analysis
 - rep counting driven by knee-angle state transitions
-- rule-based form checks for:
-  - `too_shallow`
-  - `ankle_control`
-  - `torso_lean`
-- saved session artifacts per run:
-  - `summary.json`
-  - `rep_metrics.csv`
-  - `session_report.txt`
-  - `session.mp4`
-- local video analysis for MP4 files placed in `input_videos/`
-- analytics dashboard for:
+- rule-based form checks:
+  - `too_shallow` — knee did not reach full depth (bad rep, counts against session quality)
+  - `ankle_control` — limited ankle bend detected (advisory warning)
+  - `torso_lean` — excessive forward lean detected (advisory warning)
+- bad-rep evidence export after every session:
+  - slow-motion clip at 0.25x speed per flagged rep saved in a `bad_reps` subfolder
+  - each clip covers the rep with a short buffer before and after
+  - issue label and minimum knee angle drawn on each clip frame
+  - FFmpeg chapter markers embedded into the main session video if FFmpeg is installed
+  - `bad_rep_timestamps` array written to `summary.json` for machine-readable access
+- session artefacts saved after every valid session:
+  - `summary.json` — full metrics including rep count, issue counts, and angle averages
+  - `rep_metrics.csv` — per-rep breakdown with timestamps, issues, and angle data
+  - `session_report.txt` — human-readable session summary and recommendation
+  - session video with pose landmarks rendered
+  - `session_raw.mp4` (live sessions only) — clean unoverlay video used for clip extraction
+- offline video analysis for local MP4, AVI, MOV, MKV, and M4V files
+- analytics dashboard:
   - latest meaningful session metrics
   - progress vs previous meaningful session
   - recommendation-style session insights
   - HTML analytics export
-- manual-label evaluation export for report evidence
-- session browser for opening saved videos and folders
+- manual-label evaluation harness — reads `manual_labels.csv`, exports `evaluation_results.csv` and `evaluation_report.html`
+- session browser for replaying saved videos and opening session folders
 - camera source switching for built-in, external USB, or virtual phone cameras
-- local calibration and light/dark theme settings
+- user calibration to derive personalised thresholds from sample squats
+- light and dark theme setting
 
 ## Technology Stack
 
-- Python 3.x
+- Python 3.10
 - MediaPipe
 - OpenCV
 - NumPy
+- Pillow
 
 ## Repository Structure
 
 ```text
 GymGuardian/
 |-- docs/
+|   |-- evaluation/
 |   |-- final-project-artifacts.md
 |   `-- test-plan.md
+|-- scripts/
 |-- src/
 |   |-- analysis/
 |   |-- core/
@@ -59,6 +70,7 @@ GymGuardian/
 |   |-- session/
 |   |-- ui/
 |   `-- app.py
+|-- tests/
 |-- requirements.txt
 `-- README.md
 ```
@@ -67,9 +79,10 @@ GymGuardian/
 
 ### Prerequisites
 
-- Python 3.9 or later
-- Windows desktop/laptop environment
-- Webcam with the user's lower body clearly visible
+- Python 3.10
+- Windows desktop or laptop
+- Webcam with the lower body clearly visible during squats
+- (Optional) FFmpeg on the system PATH — required only for embedding chapter markers into session videos
 
 ### Setup
 
@@ -85,37 +98,100 @@ pip install -r requirements.txt
 python src/app.py
 ```
 
-Controls:
+The dashboard opens. Use keyboard shortcuts to navigate.
 
-- `S`: start squat session
-- `V`: analyse newest local video in `input_videos/`
-- `C`: calibrate squat depth
-- `B`: browse saved sessions
-- `A`: open analytics dashboard
-- `G`: open settings
-- `K`: switch camera source from dashboard/settings
-- `Esc`: go back or exit
-- `D`: toggle debug overlay during a live session
+**Dashboard**
+
+| Key | Action |
+| --- | --- |
+| `S` | Start a live squat session |
+| `V` | Analyse the most recently placed local video file |
+| `C` | Run calibration to set personalised thresholds |
+| `A` | Open the analytics dashboard |
+| `B` | Open the session browser |
+| `G` | Open settings |
+| `K` | Switch camera source |
+| `Esc` | Exit the application |
+
+**During a live session**
+
+| Key | Action |
+| --- | --- |
+| `D` | Toggle debug overlay |
+| `Esc` | End session and save |
+
+**Session browser**
+
+| Key | Action |
+| --- | --- |
+| `P` | Play the selected session video |
+| `O` | Open the selected session folder |
+| `H` | Toggle hide-incomplete-sessions filter |
+| `Esc` | Return to dashboard |
+
+**Analytics dashboard**
+
+| Key | Action |
+| --- | --- |
+| `R` | Refresh analytics from saved sessions |
+| `E` | Export analytics report |
+| `Esc` | Return to dashboard |
+
+**Settings screen**
+
+| Key | Action |
+| --- | --- |
+| `T` | Toggle light/dark theme |
+| `H` | Toggle hide-incomplete-sessions in the browser |
+| `K` | Switch camera source |
+| `R` | Reset calibration profile to defaults |
+| `Esc` | Return to dashboard |
 
 ### Build a Windows executable
 
-The project can be packaged as a local Windows desktop executable with the
-GymGuardian icon applied to the title bar and taskbar.
+The project can be packaged as a local Windows desktop executable with the GymGuardian icon applied to the title bar and taskbar.
 
 ```powershell
 .\scripts\build_exe.ps1
 ```
 
-The generated application is written to:
+The build script installs PyInstaller into the active Python environment if it is missing. Runtime outputs such as sessions, exports, user data, and input videos remain local to the executable folder when running the packaged app.
 
-```text
-dist\GymGuardian\GymGuardian.exe
+## Squat Analysis Thresholds
+
+Default thresholds used by the rule-based analysis pipeline:
+
+| Parameter | Default | Role |
+| --- | --- | --- |
+| Standing gate | 160° | Knee angle at which standing is confirmed |
+| Down gate | 105° | Knee angle at which the squat bottom is confirmed |
+| Early bottom gate | 150° | Minimum knee angle to confirm a rep bottom |
+| Shallow flag | 110° | Knee threshold for `too_shallow` bad-rep classification |
+| Ankle advisory | 172° | Ankle angle threshold for `ankle_control` warning |
+| Torso advisory | 34° | Torso lean threshold for `torso_lean` warning |
+
+When a calibration profile is saved, thresholds are derived from the user's own sample squats rather than the fixed defaults.
+
+## Calibration
+
+The calibration routine runs for 12 seconds of continuous squatting. It requires at least 30 pose samples and at least 25° of knee-angle movement. On completion, personalised thresholds are saved and used in place of the defaults until reset.
+
+## Testing
+
+```bash
+python -m pytest
 ```
 
-The build script installs PyInstaller into the active Python environment if it
-is missing. Runtime outputs such as `sessions/`, `exports/`, `user_data/`, and
-`input_videos/` remain local to the executable folder when running the packaged
-app.
+32 automated tests across 6 test files, all passing:
+
+| File | Tests | Coverage |
+| --- | --- | --- |
+| `test_squat_logic.py` | 9 | Angle calculation, state transitions, rep counting, shallow detection, no-pose reset |
+| `test_bad_rep_export.py` | 13 | Timestamp structure, chapter metadata format, slow-clip frame count, FFmpeg graceful skip |
+| `test_analytics.py` | 3 | Meaningful-session filtering, progress comparison, video-session compatibility |
+| `test_user_profile.py` | 3 | Calibration threshold generation, settings persistence |
+| `test_session_summary.py` | 2 | JSON/CSV/report output, invalid-session handling |
+| `test_evaluation_export.py` | 2 | Label parsing, missing and incomplete session handling |
 
 ## Camera Assumptions
 

--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -4,7 +4,7 @@ This folder stores manual labels used by the evaluation harness. The harness com
 
 ## How to label a session
 
-1. Open a saved `session.mp4` from the `sessions/` folder.
+1. Open the saved session video — `session.mp4` for live sessions or `analysed_video.mp4` for offline video analysis sessions.
 2. Count the visible completed squat repetitions manually.
 3. Count how many of those repetitions should be treated as bad reps.
 4. Add one row to `manual_labels.csv`.

--- a/docs/evaluation/manual_labels.csv
+++ b/docs/evaluation/manual_labels.csv
@@ -1,1 +1,21 @@
-﻿case_id,scenario,session_folder,manual_rep_count,manual_bad_rep_count,expected_issue,manual_bad_sequence,lighting,camera_angle,notes
+case_id,scenario,session_folder,manual_rep_count,manual_bad_rep_count,expected_issue,manual_bad_sequence,lighting,camera_angle,notes
+L01,Front-facing full-depth squats,20260510_124441,10,0,none,0|0|0|0|0|0|0|0|0|0,normal,front,Phone camera via Windows camera source
+L02,Front-facing shallow squats,20260510_124730,5,5,too_shallow,1|1|1|1|1,normal,front,All reps intentionally shallow
+L03,Mixed front-facing: 5 full + 5 shallow,20260510_115144,10,5,too_shallow,0|0|0|1|1|1|0|0|1|1,normal,front,First five full-depth reps followed by five shallow reps
+L04,Slight right turn,20260510_115949,6,0,none,0|0|0|0|0|0,normal,slight-right,Reps counted if landmarks remained visible
+L05,Slight left turn,20260510_120129,6,0,none,0|0|0|0|0|0,normal,slight-left,Reps counted if landmarks remained visible
+L06,Back/away-facing test,20260510_120414,6,0,none,0|0|0|0|0|0,normal,back,Reps counted if usable landmarks remained visible
+L07,Out of frame / no pose,20260510_122828,0,0,none,,normal,out-of-frame,No reps expected; verifies no crash and no meaningful workout output
+L08,Partial lower-body visibility,20260510_123309,5,0,none,0|0|0|0|0,normal,partial,Body not fully visible; system showed repeated no_pose and unreliable landmark tracking
+L09,Low-light test,20260510_123954,5,2,too_shallow,0|0|0|1|1,low,front,Low-light condition; count may degrade and limitation noted
+L10,Calibrated full-depth squats,20260510_114002,10,0,none,0|0|0|0|0|0|0|0|0|0,normal,front,Calibration enabled; correct reps with lower bad rate
+L11,Calibrated shallow squats,20260510_114925,5,5,too_shallow,1|1|1|1|1,normal,front,Calibration enabled; shallow reps still detected as bad
+L12,Built-in webcam source,20260510_124925,5,0,none,0|0|0|0|0,normal,front,Built-in webcam lower FPS and lower image quality
+L13,Start and exit immediately,,,,,,N/A,N/A,No session folder was created; invalid quick-exit run ignored by evaluation
+L14,Long session,20260513_233625,20,8,too_shallow,0|0|0|1|1|0|0|0|1|1|0|0|0|1|1|0|0|0|1|1,normal,front/slight-right/slight-left,Longer session completed with no crash; summary and video saved
+V01,Own front-facing full-depth video,video_20260510_135538,10,0,none,0|0|0|0|0|0|0|0|0|0,normal,front,Offline local video analysis using own full-depth squat video
+V02,Own shallow video,video_20260510_135801,5,5,too_shallow,1|1|1|1|1,normal,front,Offline local video analysis using own shallow squat video
+V03,Own mixed full + shallow video,video_20260510_140033,10,5,too_shallow,0|0|0|1|1|1|0|0|1|1,normal,front,Offline local video analysis using own mixed squat video
+V04,Friend/user A normal squats,video_20260513_225054,10,0,none,0|0|0|0|0|0|0|0|0|0,normal,front,Offline local video analysis using friend/user A normal squat video
+V05,Friend/user A shallow/mixed squats,video_20260513_225240,10,5,too_shallow,0|0|0|0|0|1|1|1|1|1,normal,front,Offline local video analysis using friend/user A shallow or mixed squat video
+V06,Friend/user B normal squats,video_20260513_225406,10,0,none,0|0|0|0|0|0|0|0|0|0,normal,front,Offline local video analysis using friend/user B normal squat video

--- a/docs/final-project-artifacts.md
+++ b/docs/final-project-artifacts.md
@@ -33,6 +33,8 @@ flowchart LR
     F --> I[session_report.txt]
     B --> J[Session Recorder]
     J --> K[session.mp4]
+    B --> J2[Raw Recorder]
+    J2 --> K2[session_raw.mp4]
     D --> L[Live Overlay]
     E --> L
     G --> M[Analytics Loader]
@@ -41,6 +43,10 @@ flowchart LR
     M --> N[Analytics Dashboard]
     G --> O[Session Browser]
     K --> O
+    F --> P[Bad Rep Export]
+    K2 --> P
+    P --> Q[bad_reps/ clips]
+    P --> R[FFmpeg Chapter Markers]
 ```
 
 ## 3. Application Workflow
@@ -49,16 +55,23 @@ flowchart LR
 flowchart TD
     A[Launch App] --> B[Dashboard]
     B -->|S| C[Live Squat Session]
+    B -->|V| VA[Video Analysis]
     B -->|A| D[Analytics Dashboard]
     B -->|B| E[Session Browser]
+    B -->|C| CAL[Calibration]
+    B -->|G| SET[Settings]
     C --> F[Pose Detection + Joint Angles]
+    VA --> F
     F --> G[State Classification]
     G --> H[Rep Counting]
     H --> I[Form Checks]
     I --> J[Save Session Artifacts]
-    J --> B
+    J --> JB[Bad Rep Export]
+    JB --> B
     D -->|Esc| B
     E -->|Esc| B
+    CAL -->|Esc| B
+    SET -->|Esc| B
 ```
 
 ## 4. Squat State Transition Model
@@ -99,6 +112,8 @@ flowchart TB
         SUMMARY[session/summary.py]
         BROWSER[session/browser.py]
         INSIGHTS[session/insights.py]
+        BADEXP[session/bad_rep_export.py]
+        VIDANAL[session/video_analysis.py]
     end
 
     APP --> DETECTOR
@@ -107,9 +122,16 @@ flowchart TB
     APP --> RECORDER
     APP --> SUMMARY
     APP --> BROWSER
+    APP --> BADEXP
+    APP --> VIDANAL
     SQUAT --> CONFIG
     SUMMARY --> INSIGHTS
     BROWSER --> INSIGHTS
+    SUMMARY --> BADEXP
+    VIDANAL --> DETECTOR
+    VIDANAL --> SQUAT
+    VIDANAL --> SUMMARY
+    VIDANAL --> BADEXP
 ```
 
 ## 6. Methodology Notes
@@ -207,4 +229,3 @@ Potential next steps:
 - add calibration routines for user height and camera distance
 - add richer per-rep scoring instead of issue-only tagging
 - investigate adaptive thresholds or hybrid rule/ML classification
-- build automated evaluation scripts around saved session evidence

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,214 +1,221 @@
-# GymGuardian Test Plan
+﻿# GymGuardian Test Plan
 
 ## 1. Scope
 
-This document defines the manual test plan for the GymGuardian MVP desktop application. The current scope covers:
+This document defines the final testing approach for GymGuardian, a local OpenCV/MediaPipe desktop prototype for squat monitoring. Testing covers the complete implemented system rather than a newly trained model.
 
-- Dashboard navigation
-- Squat session start and end flow
-- Session summary and video persistence
-- Session browser navigation and open actions
-- Squat rep counting accuracy
-- Too-shallow form detection
-- Basic performance and robustness checks using the in-app debug overlay
+Covered areas:
+
+- Dashboard navigation and window behaviour
+- Live webcam squat analysis
+- Offline local video analysis
+- Pose/visibility handling
+- Rep counting and bad-rep classification
+- Calibration and default-threshold fallback
+- Camera source selection
+- Session recording and local evidence files
+- Bad-rep evidence export — slow-motion clips, chapter markers, `bad_rep_timestamps`
+- Session browser and analytics dashboard
+- HTML analytics export and evaluation export
+- Automated regression tests for deterministic logic
 
 ## 2. Test Objectives
 
-### Functionality
+### Functional correctness
 
-- Verify the dashboard, session loop, and session browser work as expected.
-- Verify sessions return to the dashboard instead of terminating the app.
-- Verify saved outputs are written to the correct timestamped session folder.
+- Verify that all major screens open from the dashboard and return safely.
+- Verify that live and offline analysis reuse the same squat-analysis pipeline.
+- Verify that session outputs are saved locally and can be reopened.
+- Verify that invalid quick-exit sessions do not pollute meaningful analytics.
 
-### Accuracy
+### Squat-analysis accuracy
 
-- Compare manual squat rep counts against app rep counts.
-- Confirm shallow squats are flagged as bad reps with the correct reason.
+- Compare manually labelled repetition counts against detected counts.
+- Confirm full-depth squats are counted as good repetitions.
+- Confirm shallow squats are counted as repetitions and classified as bad reps.
+- Confirm mixed good/bad sessions produce correct total and bad-rep counts.
 
-### Performance
+### Robustness and limitations
 
-- Check estimated FPS using the session debug overlay.
-- Confirm the app remains usable on a laptop webcam at 720p.
+- Check behaviour under rotation, low light, partial visibility, out-of-frame movement, and different camera sources.
+- Treat partial body visibility as a documented limitation when landmarks are insufficient.
+- Verify that the application does not crash during invalid, incomplete, or no-pose conditions.
 
-### Robustness
+### Evidence and reporting
 
-- Verify the app handles normal state transitions without crashing.
-- Verify missing or incomplete session artifacts are handled gracefully in the browser.
+- Generate `evaluation_results.csv` and `evaluation_report.html` from manual labels.
+- Capture screenshots of the final UI screens and exported reports.
+- Keep evaluation claims tied to saved sessions, manual labels, and automated test output.
 
 ## 3. Test Environment
 
-| Item                    | Value                                                                                                 |
-| ----------------------- | ----------------------------------------------------------------------------------------------------- |
-| Operating system        | Windows 10/11 local desktop environment                                                               |
-| Camera                  | Laptop webcam configured for 720p capture request                                                     |
-| Python version          | Python 3.10.11                                                                                        |
-| Main libraries          | `mediapipe==0.10.14`, `opencv-python==4.11.0.86`, `opencv-contrib-python==4.11.0.86`, `numpy==1.26.4` |
-| Other dependencies      | See pinned versions in `requirements.txt`                                                             |
-| App entry point         | `python src/app.py`                                                                                   |
-| Session output location | `sessions/<YYYYMMDD_HHMMSS>/`                                                                         |
+| Item | Final evaluation value |
+| --- | --- |
+| Operating system | Windows local desktop environment |
+| Application type | Python/OpenCV desktop application |
+| Python version | Python 3.10 environment used through project venv |
+| Pose component | MediaPipe pose estimation |
+| Primary live camera | Phone camera exposed to Windows as an external webcam |
+| Comparison camera | Built-in laptop webcam |
+| Offline input | Local MP4 files processed from `input_videos/` |
+| Main outputs | `summary.json`, `rep_metrics.csv`, `session_report.txt`, `session.mp4` or `analysed_video.mp4`, `session_raw.mp4` (live only), `bad_reps/` clip subfolder, analytics/evaluation HTML exports |
+| Evaluation label file | `docs/evaluation/manual_labels.csv` |
+| Evaluation command | `python src/session/evaluation_export.py` |
+| Automated test command | `python -m pytest` |
 
 ## 4. Evidence Collection
 
-- Screenshot of the dashboard, session overlay, browser, or debug overlay
-- Saved `summary.json` file from the relevant session folder
-- Saved `session.mp4` file from the relevant session folder
-- Short manual observation note, including count comparison where needed
+For each important manual scenario, save or reference:
 
-- `evidence/dashboard-navigation.png`
-- `evidence/session-summary-json.png`
-- `evidence/browser-open-folder.png`
-- `evidence/rep-count-run-01.txt`
+- The session folder name in `sessions/`
+- The saved video evidence: `session.mp4` or `analysed_video.mp4`
+- The detected summary: `summary.json`
+- The per-rep export: `rep_metrics.csv`
+- The manual label row in `docs/evaluation/manual_labels.csv`
+- Screenshots of relevant UI or exported HTML report screens
 
-## 5. FPS Measurement Approach
+Recommended final screenshots:
 
-1. Start a session from the dashboard.
-2. Press `D` to enable the debug overlay.
-3. Stand in frame for 5 seconds, then perform 5 to 10 squats.
-4. Observe the `FPS` line on screen for at least 10 seconds.
-5. Record the typical steady FPS value, plus any noticeable drops during movement.
-6. Capture a screenshot showing the debug overlay and note the lighting conditions and camera angle.
+- Main dashboard with camera source and calibration state
+- Live session overlay with full-body landmarks
+- Analytics dashboard with recent trends and session report
+- Session browser showing valid sessions with average knee/FPS columns
+- Settings screen showing theme, camera, browser, and calibration controls
+- Exported analytics HTML report
+- Exported evaluation HTML report
+- Terminal output from `python -m pytest`
 
-- Typical FPS at rest: `18`
-- Typical FPS during squats: `15-19`
-- Lowest observed FPS: `15`
-- Notes on lag or dropped responsiveness: `Minor FPS drops observed during movement, likely due to lighting conditions and increased pose estimation complexity. No major lag or freezing observed.`
+## 5. Manual Labelled Evaluation Dataset
 
-## 6. Test Cases
+The current manual label file contains 20 rows:
 
-| ID    | Scenario                                   | Steps                                                                                                                                                                      | Expected Result                                                                                                                      | Actual Result                                                                                                                                                                       | Evidence                                                                                                                          |
-| ----- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| TC-01 | Dashboard launch and menu visibility       | 1. Run `python src/app.py`. 2. Observe the first screen.                                                                                                                   | Dashboard appears with instructions for `S`, `B`, and `Q/Esc`.                                                                       | Application launched successfully. Dashboard screen displayed with options for starting a session (S), browsing sessions (B), and quitting (Q/Esc).                                 | Not required (basic navigation)                                                                                                   |
-| TC-02 | Dashboard to session navigation            | 1. From dashboard, press `S`. 2. Observe webcam session screen.                                                                                                            | App enters session mode, webcam opens, pose overlay/session UI appear.                                                               | On pressing “S”, the application entered session mode. Webcam feed opened and pose overlay with rep counter was displayed.                                                          | Not required (basic navigation)                                                                                                   |
-| TC-03 | Dashboard to browser navigation            | 1. From dashboard, press `B`. 2. Observe browser screen.                                                                                                                   | App enters browser mode and lists recent sessions newest first, or shows no-sessions message.                                        | On pressing “B”, the application entered browser mode and displayed a list of saved sessions sorted by most recent.                                                                 | Not required (basic navigation)                                                                                                   |
-| TC-04 | Session end returns to dashboard           | 1. Start a session. 2. Press `Q` or `Esc`.                                                                                                                                 | Session ends, files are saved, and app returns to dashboard instead of closing completely.                                           | Pressing “Q” or “Esc” during a session ended the session, saved session data, and returned to the dashboard without closing the application.                                        | Not required (basic navigation)                                                                                                   |
-| TC-05 | Summary JSON saved to timestamped folder   | 1. Start a short session. 2. End session. 3. Open latest folder in `sessions/`. 4. Inspect `summary.json`.                                                                 | New folder named `YYYYMMDD_HHMMSS` exists and contains `summary.json` with `started_at`, `rep_count`, `bad_rep_count`, and `events`. | A new timestamped folder was created under the sessions directory. The folder contained a summary.json file with fields including started_at, rep_count, bad_rep_count, and events. | Screenshot of sessions folder and opened summary.json file.                                                                       |
-| TC-06 | Session video saved to timestamped folder  | 1. Start a short session. 2. End session. 3. Inspect latest session folder.                                                                                                | Same session folder contains `session.mp4`; video opens and plays using a media player.                                              | The same session folder contained a session.mp4 file. The video opened successfully using the default media player and showed the recorded workout.                                 | Screenshot of session folder and video playback.                                                                                  |
-| TC-07 | Browser open session folder                | 1. Enter browser. 2. Select a session with Up/Down. 3. Press `O`.                                                                                                          | Windows Explorer opens the selected session folder.                                                                                  | Pressing “O” in the browser successfully opened the selected session folder in Windows Explorer.                                                                                    | Screenshot of opened session folder in Windows Explorer.                                                                          |
-| TC-08 | Browser open session video                 | 1. Enter browser. 2. Select a session with an existing `session.mp4`. 3. Press `P`.                                                                                        | Default Windows media player opens the selected session video.                                                                       | Pressing “P” in the browser opened the selected session.mp4 file in the default media player.                                                                                       | Screenshot of video playback after selection.                                                                                     |
-| TC-09 | Rep counting accuracy against manual count | 1. Start a session. 2. Perform 10 clearly visible full-depth squats. 3. Count manually during the run. 4. End session and inspect on-screen/app count plus `summary.json`. | App rep count matches manual count or differs by no more than the agreed tolerance for MVP.                                          | Manual count = 10, App count = 10. No discrepancy observed, indicating accurate rep detection under controlled conditions.                                                          | Screenshot of session overlay showing rep count and corresponding summary.json file (e.g., sessions/20260415_155017/summary.json) |
-| TC-10 | Too-shallow detection for bad reps         | 1. Start a session. 2. Perform 5 intentionally shallow squats without reaching full depth. 3. End session and inspect `summary.json`.                                      | Bad reps increase and relevant rep events indicate shallow failure reason such as `too_shallow`.                                     | App correctly counted repetitions and classified all shallow squats as bad reps. "too_shallow" reason recorded in summary.json.                                                     | Screenshot of summary.json showing bad_rep_count = 5                                                                              |
-| TC-11 | Mixed valid and shallow squat set          | 1. Start a session. 2. Perform 5 full squats followed by 5 shallow squats. 3. End session.                                                                                 | Total rep count reflects all valid cycles; bad rep count reflects only shallow reps.                                                 | App counted all 10 repetitions correctly. Shallow squats were recognised as valid repetitions and correctly flagged as bad reps.                                                    | Browser screenshot showing session with 5 reps and 5 bad reps.                                                                    |
-| TC-12 | Debug overlay FPS measurement              | 1. Start session. 2. Press `D`. 3. Observe overlay for at least 10 seconds while standing and squatting.                                                                   | Debug overlay toggles on, shows FPS, pose detection, knee angle, and threshold values from config.                                   | Debug overlay displayed correctly. FPS observed between 16–19. Performance remained stable with minor fluctuations during movement.                                                 | Screenshot of debug overlay with FPS visible.                                                                                     |
-| TC-13 | Debug overlay toggle off                   | 1. During session, press `D` twice.                                                                                                                                        | Debug overlay appears on first press and disappears on second press without affecting rep counting.                                  | Debug overlay successfully toggled on first press (D) and turned off on second press. No impact on session performance or rep counting.                                             | Screenshot showing overlay visible and then hidden.                                                                               |
-| TC-14 | Browser ordering by recency                | 1. Create two or more sessions at different times. 2. Open browser.                                                                                                        | Most recent session folder appears first in the list.                                                                                | Sessions displayed in descending order (newest first) based on timestamped folder names.                                                                                            | Screenshot of browser showing latest session at top.                                                                              |
-| TC-15 | Robustness when no pose is detected        | 1. Start a session. 2. Step out of camera frame or block the camera.                                                                                                       | App continues running, pose status becomes unavailable/no-pose, and no crash occurs.                                                 | When user moved out of frame, system correctly transitioned to the "no_pose" state                                                                                                  | Screenshot showing "State: no_pose" during session.                                                                               |
+| Group | Cases | Purpose |
+| --- | --- | --- |
+| Live front-facing | L01-L03 | Full-depth, shallow, and mixed squat sets |
+| Live orientation | L04-L06 | Slight right, slight left, and back-facing movement where landmarks remain usable |
+| Failure/visibility | L07-L08 | No-pose/out-of-frame and partial lower-body visibility |
+| Lighting | L09 | Low-light behaviour |
+| Calibration | L10-L11 | Calibrated full-depth and calibrated shallow tests |
+| Camera source | L12 | Built-in webcam comparison |
+| Invalid quick exit | L13 | Start and exit immediately; no session folder expected |
+| Longer run | L14 | 20-rep longer session with mixed issue sequence |
+| Offline videos | V01-V06 | Own and friend/user videos processed through local video analysis |
 
-## 7. Manual Accuracy Recording Template
+`L13` is intentionally unlabelled because no session folder was created. This verifies that invalid quick-exit runs are not treated as workout data. `L07` is kept as an incomplete/no-pose case. `L08` is retained as the main partial-visibility limitation case.
 
-| Run ID | Session Folder  | Manual Count | App Count | Difference | Manual Bad Reps | App Bad Reps | Notes                             |
-| ------ | --------------- | ------------ | --------- | ---------- | --------------- | ------------ | --------------------------------- |
-| ACC-01 | 20260422_153854 | 10           | 10        | 0          | 0               | 0            | Normal squats — accurate          |
-| ACC-02 | 20260422_154001 | 5            | 5         | 0          | 5               | 5            | Shallow squats correctly detected |
-| ACC-03 | 20260422_154138 | 10           | 10        | 0          | 5               | 5            | Mixed reps handled correctly      |
+## 6. Current Quantitative Results
 
-## 8. Initial Results
+Results generated from `docs/evaluation/manual_labels.csv` using `src/session/evaluation_export.py`:
 
-### Test Run Metadata
+| Metric | Current result | Interpretation |
+| --- | --- | --- |
+| Labelled rows | 20 | Includes live, offline, calibration, camera, failure, and quick-exit rows |
+| Evaluated meaningful rows | 18 | Excludes the incomplete no-pose row and the no-session quick-exit row |
+| Manual repetitions in evaluated rows | 148 | Ground truth from manual video/session review |
+| Detected repetitions in evaluated rows | 144 | Four-rep loss caused by the partial-visibility limitation case |
+| Aggregate rep-count accuracy | 97.3% | Calculated from absolute rep-count error |
+| Controlled visible-body accuracy | 100.0% | 143 manual reps and 143 detected reps when excluding partial visibility |
+| Manual bad reps | 40 | Ground truth bad-rep count |
+| Detected bad reps | 40 | Detected bad-rep total matched manual labels |
+| Issue match | 18/18 evaluated rows | Expected issue matched detected main issue for evaluated rows |
+| Bad-rep sequence precision | 100.0% | For rows with per-rep manual bad/good sequences |
+| Bad-rep sequence recall | 100.0% | For rows with per-rep manual bad/good sequences |
+| Average FPS across evaluated rows | about 21.3 FPS | Mixed live, offline, and built-in camera conditions |
+| Built-in webcam FPS | about 10.2 FPS in current labelled comparison | Lower image quality and lower frame rate than external phone camera |
 
-- Test date: `22/04/2026`
-- Tester: `Self`
-- Lighting conditions: `Indoor, moderate lighting (some instability observed)`
-- Camera position/angle: `Front-facing laptop webcam`
-- Distance from camera: `~1.5–2 meters`
+## 7. Manual Scenario Matrix
 
-### Summary of Outcomes
+| ID | Scenario | Manual reps | Manual bad reps | Expected issue | Evidence source |
+| --- | --- | ---: | ---: | --- | --- |
+| L01 | Front-facing full-depth squats | 10 | 0 | none | Live session folder |
+| L02 | Front-facing shallow squats | 5 | 5 | too_shallow | Live session folder |
+| L03 | Mixed front-facing full and shallow squats | 10 | 5 | too_shallow | Live session folder |
+| L04 | Slight right turn | 6 | 0 | none | Live session folder |
+| L05 | Slight left turn | 6 | 0 | none | Live session folder |
+| L06 | Back/away-facing test | 6 | 0 | none | Live session folder |
+| L07 | Out of frame / no pose | 0 | 0 | none | Incomplete/no-pose evidence |
+| L08 | Partial lower-body visibility | 5 | 0 | none | Known limitation evidence |
+| L09 | Low-light test | 5 | 2 | too_shallow | Live session folder |
+| L10 | Calibrated full-depth squats | 10 | 0 | none | Live calibrated session |
+| L11 | Calibrated shallow squats | 5 | 5 | too_shallow | Live calibrated session |
+| L12 | Built-in webcam source | 5 | 0 | none | Built-in webcam comparison |
+| L13 | Start and exit immediately | N/A | N/A | N/A | No session folder expected |
+| L14 | Long session | 20 | 8 | too_shallow | Longer live session folder |
+| V01 | Own front-facing full-depth video | 10 | 0 | none | Offline analysed video |
+| V02 | Own shallow video | 5 | 5 | too_shallow | Offline analysed video |
+| V03 | Own mixed full and shallow video | 10 | 5 | too_shallow | Offline analysed video |
+| V04 | Friend/user A normal squats | 10 | 0 | none | Offline analysed video |
+| V05 | Friend/user A shallow/mixed squats | 10 | 5 | too_shallow | Offline analysed video |
+| V06 | Friend/user B normal squats | 10 | 0 | none | Offline analysed video |
 
-| Area                  | Result     | Notes                                                |
-| --------------------- | ---------- | ---------------------------------------------------- |
-| Dashboard navigation  | Pass       | All transitions work correctly                       |
-| Session lifecycle     | Pass       | Session starts and returns to dashboard              |
-| Summary persistence   | Pass       | summary.json created correctly                       |
-| Video persistence     | Pass       | session.mp4 saved and playable                       |
-| Browser actions       | Pass       | Open and playback functions work                     |
-| Rep counting accuracy | Pass       | Accurate for correct squats                          |
-| Shallow detection     | Pass       | Incorrect reps correctly classified as "too_shallow" |
-| FPS/performance       | Acceptable | ~16–19 FPS, stable during testing                    |
+## 8. Functional Test Cases
 
-### Observed Issues
+Overall manual test coverage across all modules:
 
-- `Issue 1:` `FPS varies depending on lighting conditions and environmental factors.`
-- `Issue 2:` `Pose detection accuracy slightly decreases when the user rotates away from a front-facing position.`
+| Total cases | Pass | Fail | Not run | Pass rate |
+| --- | --- | --- | --- | --- |
+| 180 | 166 | 1 | 13 | 92.2% |
 
-### Evidence Checklist
+The full case matrix is maintained in `GymGuardian_Test_Cases.xlsx`. The table below lists the core functional scenarios.
 
-- Dashboard screenshot: `Yes`
-- Session overlay screenshot: `Yes`
-- Debug overlay screenshot: `Yes`
-- Browser screenshot: `Yes`
-- Sample `summary.json`: `Yes`
-- Sample `session.mp4`: `Yes`
+| ID | Scenario | Expected Result | Status |
+| --- | --- | --- | --- |
+| FT-01 | Launch dashboard | Dashboard renders with all current actions | Pass |
+| FT-02 | Start live session | Camera opens and live overlay appears | Pass |
+| FT-03 | Analyse local video | New `video_<timestamp>` session is saved with annotated video and summary | Pass |
+| FT-04 | Open analytics dashboard | Latest meaningful session, trends, progress, and report section render | Pass |
+| FT-05 | Export analytics report | `exports/analytics_report.html` is created and opens | Pass |
+| FT-06 | Open session browser | Valid sessions are listed newest first | Pass |
+| FT-07 | Open saved video | Browser opens selected video file | Pass |
+| FT-08 | Open saved folder | Browser opens selected session folder | Pass |
+| FT-09 | Open settings | Theme, camera, browser, and calibration controls render | Pass |
+| FT-10 | Toggle theme | Light/dark theme changes without changing analysis logic | Pass |
+| FT-11 | Switch camera source | Camera index cycles and selected camera label updates | Pass |
+| FT-12 | Reset calibration | Calibration profile is removed and defaults are restored | Pass |
+| FT-13 | Window minimize/maximize | Static screens redraw cleanly after restore | Pass |
+| FT-14 | Window close button | Application exits safely from the close button | Pass |
+| FT-15 | Quick start and exit | No meaningful workout session is created or counted | Pass |
 
-## 9. Evaluation Harness
+## 9. Automated Testing
 
-GymGuardian includes a report-focused evaluation harness for comparing manually
-labelled saved sessions against detected session outputs. The label file is
-stored at `docs/evaluation/manual_labels.csv`.
+Automated tests validate deterministic project logic that can run without a webcam.
 
-### Labelling Process
-
-1. Review a saved `session.mp4` from `sessions/<timestamp>/`.
-2. Count the visible completed squat repetitions manually.
-3. Count how many repetitions should be classified as bad.
-4. Record the expected main issue, such as `too_shallow`, `ankle_control`,
-   `torso_lean`, or `none`.
-5. Optionally record a per-repetition bad sequence using `0` for good and `1`
-   for bad, for example `0,0,1,1`.
-
-### Running the Harness
-
-```powershell
-.\venv\Scripts\python.exe src\session\evaluation_export.py
-```
-
-The harness exports:
-
-- `exports/evaluation_results.csv`
-- `exports/evaluation_report.html`
-
-### Metrics Produced
-
-- Rep count error and rep count accuracy
-- Bad-rep count error and bad-rep rate difference
-- Issue match against the manually expected issue
-- Optional bad-rep precision and recall from per-rep labels
-- Average FPS from saved session summaries
-
-This evaluates the full GymGuardian system output. It should not be described
-as custom model-training accuracy because the project uses MediaPipe pose
-estimation with rule-based squat analysis.
-
-## 10. Automated Testing
-
-Automated testing was added to support supervisor feedback and strengthen the
-final evaluation evidence. These tests focus on deterministic project logic
-that can run without a webcam.
-
-### Automated Test Command
+Command:
 
 ```powershell
-.\venv\Scripts\python.exe -m pytest
+python -m pytest
 ```
 
-### Automated Coverage
+32 tests across 6 files, all passing:
 
-| Test Area | Automated Coverage |
-| --- | --- |
-| Squat logic | Joint-angle calculation, full-depth rep counting, shallow-rep classification, and no-pose reset handling |
-| Session summary | `summary.json`, `rep_metrics.csv`, `session_report.txt`, and `valid_session` output |
-| Analytics | Meaningful-session filtering, latest/previous comparison, issue totals, and FPS averaging |
-| Calibration/settings | Adaptive threshold generation, invalid calibration rejection, and settings normalization |
-| Evaluation harness | Manual label parsing, valid-session scoring, missing sessions, incomplete sessions, and sequence precision/recall |
+| File | Tests | Coverage |
+| --- | --- | --- |
+| `test_squat_logic.py` | 9 | Angle calculation, state transitions, full-depth reps, shallow reps, no-pose reset |
+| `test_bad_rep_export.py` | 13 | `bad_rep_timestamps` structure, chapter metadata format, slow-clip frame count, FFmpeg graceful skip |
+| `test_analytics.py` | 3 | Meaningful-session filtering, latest/previous comparison, video-session compatibility |
+| `test_user_profile.py` | 3 | Adaptive threshold generation, invalid calibration rejection, settings persistence |
+| `test_session_summary.py` | 2 | `summary.json`, `rep_metrics.csv`, report output, valid-session handling |
+| `test_evaluation_export.py` | 2 | Manual label parsing, missing sessions, incomplete session handling |
 
-### Documentation Note
+The automated suite supports regression testing. It does not claim to measure MediaPipe model accuracy or real webcam performance.
 
-The automated suite validates application logic and saved-output processing. It
-does not claim to test MediaPipe model accuracy or webcam performance. Live
-camera behaviour, lighting sensitivity, and camera-angle limitations remain part
-of the manual scenario-based evaluation.
+## 10. Known Issues and Limitations
 
-### Evidence To Capture
+| Limitation | Evidence | Mitigation / Report Treatment |
+| --- | --- | --- |
+| Partial lower-body visibility can under-count reps | L08 detected fewer reps than the manual count | Report as a camera/visibility limitation, not a hidden defect |
+| Built-in webcam has lower FPS and image quality | L12 average FPS lower than phone camera source | Camera source selection allows using a better external/phone camera |
+| Low light affects landmark reliability | L09 low-light scenario included | State stable lighting as an operating assumption |
+| 2D angle approximation depends on camera placement | Rotation/orientation scenarios included | Use front or near-front camera setup for best results |
+| This is not a medical diagnosis system | Feedback is rule-based and movement-quality focused | Use coaching/prototype wording only |
 
-- Screenshot of the terminal command `.\venv\Scripts\python.exe -m pytest`.
-- Screenshot showing the final result, for example `13 passed`.
-- Include the command and result in the Testing and Evaluation section of the
-  final report.
+## 11. Final Evidence Checklist
+
+- `docs/evaluation/manual_labels.csv` updated with final manual labels
+- `exports/evaluation_results.csv` regenerated from the final labels
+- `exports/evaluation_report.html` regenerated from the final labels
+- `exports/analytics_report.html` regenerated after final sessions
+- `GymGuardian_Test_Cases.xlsx` updated with final test coverage
+- Terminal screenshot of automated tests
+- Screenshots of the final application screens
+- Sample session artefacts retained for appendix evidence

--- a/src/analysis/squat.py
+++ b/src/analysis/squat.py
@@ -318,6 +318,7 @@ class RepCounterUpdate:
     min_knee_angle: Optional[float] = None
     min_ankle_angle: Optional[float] = None
     max_torso_angle: Optional[float] = None
+    rep_start_time: Optional[float] = None
 
 
 class SquatRepCounter:
@@ -435,6 +436,7 @@ class SquatRepCounter:
         min_knee_angle = self._min_knee_angle
         min_ankle_angle = self._min_ankle_angle
         max_torso_angle = self._max_torso_angle
+        rep_start_time = self._rep_start_time
 
         issues: list[str] = []
         if min_knee_angle is None or min_knee_angle > self._config.shallow_knee_angle:
@@ -468,6 +470,7 @@ class SquatRepCounter:
             min_knee_angle=min_knee_angle,
             min_ankle_angle=min_ankle_angle,
             max_torso_angle=max_torso_angle,
+            rep_start_time=rep_start_time,
         )
 
     def _clear_cycle_metrics(self) -> None:

--- a/src/app.py
+++ b/src/app.py
@@ -7,6 +7,7 @@ from ctypes import wintypes
 from datetime import datetime
 from functools import lru_cache
 import os
+import shutil
 import subprocess
 import time
 
@@ -15,7 +16,7 @@ import numpy as np
 
 from analysis.squat import SquatRepCounter, SquatStateAnalyzer
 from core.config import CALIBRATION_CONFIG, SquatConfig
-from core.paths import INPUT_VIDEOS_DIR, SESSIONS_DIR
+from core.paths import ASSETS_DIR, INPUT_VIDEOS_DIR, SESSIONS_DIR
 from core.user_profile import (
     build_calibration_profile,
     load_app_settings,
@@ -44,6 +45,7 @@ from ui.overlay import OverlayRenderer
 
 
 WINDOW_NAME = "GymGuardian"
+WINDOW_APP_ID = "GymGuardian.SquatCoach.Prototype.Final"
 FRAME_WIDTH = 1280
 FRAME_HEIGHT = 720
 APP_BG = (229, 237, 233)
@@ -70,6 +72,99 @@ FALLBACK_CAMERA_LABELS = {
 _WINDOW_MAXIMIZED = False
 _LAST_CAMERA_WARNING: str | None = None
 _LAST_CAMERA_WARNING_AT = 0.0
+
+
+def _set_windows_app_id() -> None:
+    """Give Windows a stable taskbar identity when running from Python or an exe."""
+    if os.name != "nt":
+        return
+
+    try:
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(WINDOW_APP_ID)
+    except Exception:
+        return
+
+
+def _set_window_icon(window_name: str) -> None:
+    """Apply the GymGuardian icon to the native OpenCV window on Windows."""
+    if os.name != "nt":
+        return
+
+    icon_path = ASSETS_DIR / "gymguardian.ico"
+    if not icon_path.exists():
+        return
+
+    try:
+        ctypes.windll.user32.FindWindowW.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR]
+        ctypes.windll.user32.FindWindowW.restype = wintypes.HWND
+        hwnd = ctypes.windll.user32.FindWindowW(None, window_name)
+        if not hwnd:
+            return
+
+        ctypes.windll.user32.LoadImageW.argtypes = [
+            wintypes.HINSTANCE,
+            wintypes.LPCWSTR,
+            wintypes.UINT,
+            ctypes.c_int,
+            ctypes.c_int,
+            wintypes.UINT,
+        ]
+        ctypes.windll.user32.LoadImageW.restype = wintypes.HANDLE
+        ctypes.windll.user32.SendMessageW.argtypes = [
+            wintypes.HWND,
+            wintypes.UINT,
+            wintypes.WPARAM,
+            wintypes.LPARAM,
+        ]
+        ctypes.windll.user32.SendMessageW.restype = wintypes.LPARAM
+
+        image_icon = 1
+        lr_load_from_file = 0x00000010
+        wm_set_icon = 0x0080
+        icon_small = 0
+        icon_big = 1
+        icon_small2 = 2
+        gclp_hicon = -14
+        gclp_hiconsm = -34
+
+        def load_icon(size: int):
+            return ctypes.windll.user32.LoadImageW(
+                None,
+                str(icon_path),
+                image_icon,
+                size,
+                size,
+                lr_load_from_file,
+            )
+
+        hicon_big = load_icon(256) or load_icon(64) or load_icon(32)
+        hicon_small = load_icon(32) or load_icon(16) or hicon_big
+
+        if hicon_small:
+            ctypes.windll.user32.SendMessageW(hwnd, wm_set_icon, icon_small, hicon_small)
+            ctypes.windll.user32.SendMessageW(hwnd, wm_set_icon, icon_small2, hicon_small)
+        if hicon_big:
+            ctypes.windll.user32.SendMessageW(hwnd, wm_set_icon, icon_big, hicon_big)
+
+        # Some OpenCV/Win32 windows use the class icon for the taskbar image.
+        if hasattr(ctypes.windll.user32, "SetClassLongPtrW"):
+            ctypes.windll.user32.SetClassLongPtrW.argtypes = [
+                wintypes.HWND,
+                ctypes.c_int,
+                ctypes.c_void_p,
+            ]
+            ctypes.windll.user32.SetClassLongPtrW.restype = ctypes.c_void_p
+            if hicon_big:
+                ctypes.windll.user32.SetClassLongPtrW(hwnd, gclp_hicon, hicon_big)
+            if hicon_small:
+                ctypes.windll.user32.SetClassLongPtrW(hwnd, gclp_hiconsm, hicon_small)
+        else:
+            if hicon_big:
+                ctypes.windll.user32.SetClassLongW(hwnd, gclp_hicon, hicon_big)
+            if hicon_small:
+                ctypes.windll.user32.SetClassLongW(hwnd, gclp_hiconsm, hicon_small)
+    except Exception:
+        return
 
 
 def _sync_app_background(overlay: OverlayRenderer) -> None:
@@ -220,6 +315,7 @@ def _initialize_window() -> None:
     for _ in range(3):
         cv2.waitKey(1)
 
+    _set_window_icon(WINDOW_NAME)
     _maximize_window(WINDOW_NAME)
     for _ in range(5):
         cv2.waitKey(1)
@@ -426,6 +522,8 @@ def run_session(overlay: OverlayRenderer) -> bool:
     feedback_level = "info"
     feedback_until = 0.0
     keep_running = True
+    raw_writer = None
+    raw_video_path = None
 
     try:
         while True:
@@ -442,6 +540,18 @@ def run_session(overlay: OverlayRenderer) -> bool:
                 capture_fps = cap.get(cv2.CAP_PROP_FPS)
                 recorder.start(frame_size=frame_size, fps=capture_fps)
                 recorder_started = True
+                raw_fps = capture_fps if capture_fps and capture_fps > 1 else 30.0
+                raw_video_path = session_dir / "session_raw.mp4"
+                session_dir.mkdir(parents=True, exist_ok=True)
+                raw_writer = cv2.VideoWriter(
+                    str(raw_video_path),
+                    cv2.VideoWriter_fourcc(*"mp4v"),
+                    raw_fps,
+                    frame_size,
+                )
+                if not raw_writer.isOpened():
+                    raw_writer = None
+                    raw_video_path = None
 
             timestamp = time.time()
             if previous_frame_time > 0:
@@ -474,6 +584,7 @@ def run_session(overlay: OverlayRenderer) -> bool:
                 summary.record_completed_rep(
                     rep_index=rep_counter.rep_count,
                     timestamp=elapsed,
+                    start_timestamp=rep_update.rep_start_time or elapsed,
                     is_bad=rep_update.is_bad,
                     issues=rep_update.issues,
                     min_knee_angle=rep_update.min_knee_angle,
@@ -499,6 +610,8 @@ def run_session(overlay: OverlayRenderer) -> bool:
                 squat_config,
                 is_in_rep=rep_counter.in_rep,
             )
+            if raw_writer is not None:
+                raw_writer.write(frame)
             overlay.draw(
                 frame,
                 results,
@@ -545,12 +658,20 @@ def run_session(overlay: OverlayRenderer) -> bool:
     finally:
         summary.rep_count = rep_counter.rep_count
         summary.bad_rep_count = rep_counter.bad_rep_count
-        saved_path = summary.save(session_dir)
         recorder.stop()
+        if raw_writer is not None:
+            raw_writer.release()
 
         detector.close()
         cap.release()
 
+        if summary.rep_count <= 0:
+            if session_dir.exists():
+                shutil.rmtree(session_dir, ignore_errors=True)
+            print("Empty session discarded: no completed reps recorded.")
+            return keep_running
+
+        saved_path = summary.save(session_dir)
         print(f"Session summary saved: {saved_path}")
         rep_metrics_path = session_dir / "rep_metrics.csv"
         if rep_metrics_path.exists():
@@ -560,6 +681,14 @@ def run_session(overlay: OverlayRenderer) -> bool:
             print(f"Session report exported: {session_report_path}")
         if recorder_started and recorder.output_path.exists():
             print(f"Session video path: {recorder.output_path}")
+            from session.bad_rep_export import run_bad_rep_export
+            run_bad_rep_export(
+                session_dir,
+                recorder.output_path,
+                summary,
+                recorder._fps,
+                source_video_path=raw_video_path,
+            )
 
     return keep_running
 
@@ -822,6 +951,7 @@ def run_settings(overlay: OverlayRenderer) -> bool:
 
 
 def main() -> None:
+    _set_windows_app_id()
     settings = load_app_settings()
     overlay = OverlayRenderer(settings.theme)
     _sync_app_background(overlay)

--- a/src/core/paths.py
+++ b/src/core/paths.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if getattr(sys, "frozen", False):
+    PROJECT_ROOT = Path(sys.executable).resolve().parent
+    RESOURCE_ROOT = Path(getattr(sys, "_MEIPASS", PROJECT_ROOT))
+else:
+    PROJECT_ROOT = Path(__file__).resolve().parents[2]
+    RESOURCE_ROOT = PROJECT_ROOT
 
 SESSIONS_DIR = PROJECT_ROOT / "sessions"
 INPUT_VIDEOS_DIR = PROJECT_ROOT / "input_videos"
 
-ASSETS_DIR = PROJECT_ROOT / "assets"
+ASSETS_DIR = RESOURCE_ROOT / "assets"
 MODELS_DIR = ASSETS_DIR / "models"
 POSE_TASK_FILE = MODELS_DIR / "pose_landmarker_full.task"

--- a/src/core/user_profile.py
+++ b/src/core/user_profile.py
@@ -60,7 +60,7 @@ class CalibrationProfile:
 @dataclass(frozen=True)
 class AppSettings:
     theme: str = "light"
-    hide_incomplete_sessions: bool = False
+    hide_incomplete_sessions: bool = True
     camera_index: int = 0
 
 
@@ -111,7 +111,7 @@ def load_app_settings() -> AppSettings:
             theme = "light"
         return AppSettings(
             theme=theme,
-            hide_incomplete_sessions=bool(data.get("hide_incomplete_sessions", False)),
+            hide_incomplete_sessions=bool(data.get("hide_incomplete_sessions", True)),
             camera_index=_normalize_camera_index(data.get("camera_index", 0)),
         )
     except (OSError, TypeError, ValueError, json.JSONDecodeError):

--- a/src/session/bad_rep_export.py
+++ b/src/session/bad_rep_export.py
@@ -1,0 +1,263 @@
+"""Post-session export: slow-motion bad-rep clips (OpenCV) and chapter metadata (FFmpeg)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import cv2
+
+from session.summary import CompletedRep, SessionSummary
+
+_BUFFER_SEC = 0.5
+
+
+def run_bad_rep_export(
+    session_dir: Path,
+    video_path: Optional[Path],
+    summary: SessionSummary,
+    fps: float,
+    source_video_path: Optional[Path] = None,
+) -> None:
+    """Generate slow-motion bad-rep clips and embed chapter markers after a session.
+
+    Called automatically after every session save.  Does nothing if there are no bad
+    reps or the session video is unavailable.  FFmpeg chapter embedding is attempted
+    after clip generation; if FFmpeg is not on PATH a warning is printed and the
+    original video is left unchanged.
+
+    source_video_path: if provided and exists, clips are extracted from this video
+    instead of video_path (useful when video_path has the UI overlay baked in).
+    """
+    bad_reps = [r for r in summary.completed_reps if r.is_bad or bool(r.issues)]
+    if not bad_reps:
+        return
+
+    if video_path is None or not video_path.exists():
+        print(
+            f"[bad_rep_export] Video not found - skipping clip extraction: {video_path}"
+        )
+        return
+
+    clip_source = (
+        source_video_path
+        if source_video_path is not None and source_video_path.exists()
+        else video_path
+    )
+    _generate_slow_clips(session_dir, clip_source, bad_reps, fps)
+
+    total_sec = _video_duration_sec(video_path, fps)
+    bad_rep_timestamps = [
+        {
+            "rep_number": r.rep_index,
+            "issue": r.issues[0] if r.issues else "unknown",
+            "start_sec": round(r.start_timestamp, 2),
+            "end_sec": round(r.timestamp, 2),
+        }
+        for r in bad_reps
+    ]
+    _embed_chapters(video_path, bad_rep_timestamps, total_sec)
+
+
+# ---------------------------------------------------------------------------
+# Feature B — slow-motion clips
+# ---------------------------------------------------------------------------
+
+def _generate_slow_clips(
+    session_dir: Path,
+    video_path: Path,
+    bad_reps: list[CompletedRep],
+    fps: float,
+) -> None:
+    clips_dir = session_dir / "bad_reps"
+    clips_dir.mkdir(exist_ok=True)
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        print(
+            f"[bad_rep_export] Cannot open video for clip extraction: {video_path}"
+        )
+        cap.release()
+        return
+
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    cap.release()
+
+    for rep in bad_reps:
+        issue_tag = rep.issues[0] if rep.issues else "unknown"
+        out_path = clips_dir / f"bad_rep_{rep.rep_index}_{issue_tag}.mp4"
+        _write_slow_clip(
+            video_path=video_path,
+            out_path=out_path,
+            rep=rep,
+            fps=fps,
+            frame_size=(w, h),
+            total_frames=total_frames,
+        )
+        print(f"[bad_rep_export] Saved clip: {out_path.name}")
+
+
+def _write_slow_clip(
+    video_path: Path,
+    out_path: Path,
+    rep: CompletedRep,
+    fps: float,
+    frame_size: tuple[int, int],
+    total_frames: int,
+) -> None:
+    """Write a clip for one bad rep: 0.5 s pre-buffer + 0.25x slow-mo + 0.5 s post-buffer.
+
+    The bad-rep portion is slowed by writing each frame four times.  A text banner
+    showing the rep number, issue type, and minimum knee angle is drawn on every
+    frame of the clip.
+    """
+    clip_start = max(0.0, rep.start_timestamp - _BUFFER_SEC)
+    clip_end = min(total_frames / fps, rep.timestamp + _BUFFER_SEC)
+
+    clip_start_frame = int(clip_start * fps)
+    rep_start_frame = int(rep.start_timestamp * fps)
+    rep_end_frame = int(rep.timestamp * fps)
+    clip_end_frame = min(total_frames - 1, int(clip_end * fps))
+
+    cap = cv2.VideoCapture(str(video_path))
+    cap.set(cv2.CAP_PROP_POS_FRAMES, clip_start_frame)
+
+    writer = cv2.VideoWriter(
+        str(out_path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        fps,
+        frame_size,
+    )
+
+    issue_label = rep.issues[0] if rep.issues else "unknown"
+    all_issues = ", ".join(rep.issues) if rep.issues else "none"
+    angle_label = (
+        f"Min knee: {rep.min_knee_angle:.1f} deg"
+        if rep.min_knee_angle is not None
+        else ""
+    )
+    banner_lines = [f"Rep {rep.rep_index} - {issue_label}", f"Issues: {all_issues}"]
+    if angle_label:
+        banner_lines.append(angle_label)
+
+    for frame_idx in range(clip_start_frame, clip_end_frame + 1):
+        ok, frame = cap.read()
+        if not ok:
+            break
+
+        _draw_banner(frame, banner_lines)
+
+        repeat = 4 if rep_start_frame <= frame_idx < rep_end_frame else 1
+        for _ in range(repeat):
+            writer.write(frame)
+
+    cap.release()
+    writer.release()
+
+
+def _draw_banner(frame, lines: list[str]) -> None:
+    y = 30
+    for line in lines:
+        cv2.putText(
+            frame, line, (10, y),
+            cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 3, cv2.LINE_AA,
+        )
+        cv2.putText(
+            frame, line, (10, y),
+            cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 1, cv2.LINE_AA,
+        )
+        y += 28
+
+
+# ---------------------------------------------------------------------------
+# Feature A — FFmpeg chapter embedding
+# ---------------------------------------------------------------------------
+
+def _embed_chapters(
+    video_path: Path,
+    bad_rep_timestamps: list[dict],
+    total_sec: float,
+) -> None:
+    """Embed FFMETADATA1 chapter markers into video_path in-place via FFmpeg.
+
+    Skips gracefully if FFmpeg is not installed — prints a console warning and
+    leaves the original file unchanged.
+    """
+    if not shutil.which("ffmpeg"):
+        print(
+            "[bad_rep_export] FFmpeg not found — chapter markers skipped. "
+            "Install FFmpeg (e.g. winget install ffmpeg) to enable chapter embedding."
+        )
+        return
+
+    total_ms = int(total_sec * 1000)
+    chapters: list[tuple[int, int, str]] = [(0, total_ms, "Session Start")]
+    for entry in sorted(bad_rep_timestamps, key=lambda e: e["start_sec"]):
+        start_ms = int(entry["start_sec"] * 1000)
+        end_ms = int(entry["end_sec"] * 1000)
+        title = f"Rep {entry['rep_number']} — {entry['issue']}"
+        chapters.append((start_ms, end_ms, title))
+    chapters.append((total_ms, total_ms, "Session End"))
+
+    metadata_text = build_ffmetadata_string(chapters)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        meta_path = Path(tmp) / "chapters.ffmetadata"
+        meta_path.write_text(metadata_text, encoding="utf-8")
+        out_path = Path(tmp) / "chaptered.mp4"
+
+        cmd = [
+            "ffmpeg", "-y",
+            "-i", str(video_path),
+            "-i", str(meta_path),
+            "-map_metadata", "1",
+            "-codec", "copy",
+            str(out_path),
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, timeout=120)
+            if result.returncode != 0:
+                err = result.stderr.decode(errors="replace")[:300]
+                print(f"[bad_rep_export] FFmpeg chapter embed failed: {err}")
+                return
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            print(f"[bad_rep_export] FFmpeg chapter embed error: {exc}")
+            return
+
+        out_path.replace(video_path)
+        print(f"[bad_rep_export] Chapter markers embedded into: {video_path.name}")
+
+
+def build_ffmetadata_string(chapters: list[tuple[int, int, str]]) -> str:
+    """Build an FFMETADATA1 chapter string from (start_ms, end_ms, title) tuples.
+
+    Exposed as a public function so it can be tested without a video file.
+    """
+    lines = [";FFMETADATA1", ""]
+    for start_ms, end_ms, title in chapters:
+        lines += [
+            "[CHAPTER]",
+            "TIMEBASE=1/1000",
+            f"START={start_ms}",
+            f"END={end_ms}",
+            f"title={title}",
+            "",
+        ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _video_duration_sec(video_path: Path, fallback_fps: float) -> float:
+    cap = cv2.VideoCapture(str(video_path))
+    frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+    file_fps = cap.get(cv2.CAP_PROP_FPS) or fallback_fps
+    cap.release()
+    return frames / file_fps if file_fps > 0 else 0.0

--- a/src/session/browser.py
+++ b/src/session/browser.py
@@ -22,6 +22,8 @@ class SessionBrowserItem:
     valid_session: bool
     rep_count: Optional[int]
     bad_rep_count: Optional[int]
+    avg_knee_angle: Optional[float] = None
+    avg_fps: Optional[float] = None
 
 
 @dataclass(frozen=True)
@@ -104,6 +106,8 @@ def list_recent_sessions(
         data = _load_summary_data(summary_path)
         rep_count = _safe_int(data.get("rep_count")) if data else None
         bad_rep_count = _safe_int(data.get("bad_rep_count")) if data else None
+        avg_knee_angle = _safe_float(data.get("avg_knee_angle")) if data else None
+        avg_fps = _safe_float(data.get("avg_fps")) if data else None
         valid_session = _derive_valid_session(data, rep_count)
 
         items.append(
@@ -115,6 +119,8 @@ def list_recent_sessions(
                 valid_session=valid_session,
                 rep_count=rep_count,
                 bad_rep_count=bad_rep_count,
+                avg_knee_angle=avg_knee_angle,
+                avg_fps=avg_fps,
             )
         )
 
@@ -306,9 +312,7 @@ def _derive_valid_session(data: Optional[dict], rep_count: Optional[int]) -> boo
 
 
 def _format_session_label(folder_name: str, valid_session: bool) -> str:
-    if valid_session:
-        return folder_name
-    return f"{folder_name} (incomplete)"
+    return folder_name
 
 
 def _safe_int(value) -> Optional[int]:

--- a/src/session/evaluation_export.py
+++ b/src/session/evaluation_export.py
@@ -363,7 +363,7 @@ def build_html_report(
         linear-gradient(135deg, #f8fbf8 0%, var(--bg) 100%);
       color: var(--ink);
     }}
-    main {{ max-width: 1240px; margin: 0 auto; padding: 40px 28px 56px; }}
+    main {{ width: min(1560px, calc(100vw - 32px)); margin: 0 auto; padding: 40px 16px 56px; }}
     header {{ display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; margin-bottom: 26px; }}
     h1 {{ margin: 0 0 8px; font-size: 42px; letter-spacing: -0.04em; }}
     h2 {{ margin: 0 0 16px; font-size: 22px; letter-spacing: -0.02em; }}
@@ -373,10 +373,11 @@ def build_html_report(
     .card {{ background: rgba(255, 255, 255, 0.9); border: 1px solid var(--line); border-radius: 22px; padding: 22px; box-shadow: var(--shadow); }}
     .metric-label {{ color: var(--muted); font-size: 13px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.08em; }}
     .metric-value {{ margin-top: 10px; font-size: 30px; font-weight: 850; letter-spacing: -0.03em; }}
-    .section {{ margin-top: 18px; background: rgba(255, 255, 255, 0.9); border: 1px solid var(--line); border-radius: 24px; padding: 24px; box-shadow: var(--shadow); overflow-x: auto; }}
-    table {{ width: 100%; border-collapse: collapse; }}
-    th, td {{ text-align: left; padding: 12px 10px; border-bottom: 1px solid #d8e4da; font-size: 14px; vertical-align: top; }}
-    th {{ color: var(--muted); background: var(--panel-soft); text-transform: uppercase; letter-spacing: 0.06em; font-size: 12px; white-space: nowrap; }}
+    .section {{ margin-top: 18px; background: rgba(255, 255, 255, 0.9); border: 1px solid var(--line); border-radius: 24px; padding: 24px; box-shadow: var(--shadow); }}
+    table {{ width: 100%; border-collapse: collapse; table-layout: fixed; }}
+    th, td {{ text-align: left; padding: 12px 10px; border-bottom: 1px solid #d8e4da; font-size: 14px; vertical-align: top; overflow-wrap: anywhere; }}
+    th {{ color: var(--muted); background: var(--panel-soft); text-transform: uppercase; letter-spacing: 0.05em; font-size: 12px; line-height: 1.25; }}
+    .results-table th, .results-table td {{ padding: 11px 8px; font-size: 13px; }}
     tr:last-child td {{ border-bottom: 0; }}
     .note {{ margin-top: 20px; padding: 16px 18px; border-left: 5px solid var(--green); background: #edf7ef; border-radius: 14px; }}
     .good {{ color: var(--green); font-weight: 800; }}
@@ -580,7 +581,6 @@ def _results_table(results: list[EvaluationResult]) -> str:
             f"<td>{escape(_format_count_pair(result.manual_rep_count, result.detected_rep_count))}</td>"
             f"<td>{escape(_format_count_pair(result.manual_bad_rep_count, result.detected_bad_rep_count))}</td>"
             f"<td>{escape(_format_percent(result.rep_accuracy_percent))}</td>"
-            f"<td>{escape(_format_signed_float(result.bad_rate_difference, ' pts'))}</td>"
             f"<td>{escape(result.expected_issue or 'N/A')}</td>"
             f"<td>{escape(result.detected_issue or 'none')}</td>"
             f"<td class=\"{issue_class}\">{escape(result.issue_match)}</td>"
@@ -589,10 +589,15 @@ def _results_table(results: list[EvaluationResult]) -> str:
             "</tr>"
         )
     return (
-        "<table>"
+        '<table class="results-table">'
+        "<colgroup>"
+        '<col style="width:4%"><col style="width:12%"><col style="width:11%"><col style="width:9%">'
+        '<col style="width:6%"><col style="width:6%"><col style="width:8%">'
+        '<col style="width:10%"><col style="width:10%"><col style="width:8%"><col style="width:6%"><col style="width:10%">'
+        "</colgroup>"
         "<thead><tr>"
         "<th>Case</th><th>Scenario</th><th>Session</th><th>Status</th>"
-        "<th>Reps M/D</th><th>Bad M/D</th><th>Rep accuracy</th><th>Bad-rate diff</th>"
+        "<th>Reps M/D</th><th>Bad M/D</th><th>Rep accuracy</th>"
         "<th>Expected issue</th><th>Detected issue</th><th>Issue match</th><th>FPS</th><th>Message</th>"
         "</tr></thead><tbody>"
         + "".join(rows)

--- a/src/session/summary.py
+++ b/src/session/summary.py
@@ -28,6 +28,7 @@ class CompletedRep:
     min_knee_angle: Optional[float] = None
     min_ankle_angle: Optional[float] = None
     max_torso_angle: Optional[float] = None
+    start_timestamp: float = 0.0
 
 
 @dataclass
@@ -90,6 +91,7 @@ class SessionSummary:
         min_knee_angle: Optional[float],
         min_ankle_angle: Optional[float],
         max_torso_angle: Optional[float],
+        start_timestamp: float = 0.0,
     ) -> None:
         self.completed_reps.append(
             CompletedRep(
@@ -100,6 +102,7 @@ class SessionSummary:
                 min_knee_angle=self._round_optional(min_knee_angle),
                 min_ankle_angle=self._round_optional(min_ankle_angle),
                 max_torso_angle=self._round_optional(max_torso_angle),
+                start_timestamp=round(start_timestamp, 2),
             )
         )
 
@@ -125,6 +128,7 @@ class SessionSummary:
                 {
                     "rep_index": rep.rep_index,
                     "timestamp": rep.timestamp,
+                    "start_timestamp": rep.start_timestamp,
                     "is_bad": rep.is_bad,
                     "issues": list(rep.issues),
                     "min_knee_angle": rep.min_knee_angle,
@@ -132,6 +136,16 @@ class SessionSummary:
                     "max_torso_angle": rep.max_torso_angle,
                 }
                 for rep in self.completed_reps
+            ],
+            "bad_rep_timestamps": [
+                {
+                    "rep_number": rep.rep_index,
+                    "issue": rep.issues[0] if rep.issues else "unknown",
+                    "start_sec": rep.start_timestamp,
+                    "end_sec": rep.timestamp,
+                }
+                for rep in self.completed_reps
+                if rep.is_bad or rep.issues
             ],
             "events": [
                 {
@@ -161,6 +175,7 @@ class SessionSummary:
             writer.writerow(
                 [
                     "rep_index",
+                    "start_timestamp_seconds",
                     "timestamp_seconds",
                     "is_bad",
                     "issues",
@@ -173,6 +188,7 @@ class SessionSummary:
                 writer.writerow(
                     [
                         rep.rep_index,
+                        f"{rep.start_timestamp:.2f}",
                         f"{rep.timestamp:.2f}",
                         int(rep.is_bad),
                         ", ".join(rep.issues),

--- a/src/session/video_analysis.py
+++ b/src/session/video_analysis.py
@@ -159,6 +159,7 @@ def analyze_video_file(
                 summary.record_completed_rep(
                     rep_index=rep_counter.rep_count,
                     timestamp=frame_time,
+                    start_timestamp=rep_update.rep_start_time or frame_time,
                     is_bad=rep_update.is_bad,
                     issues=rep_update.issues,
                     min_knee_angle=rep_update.min_knee_angle,
@@ -213,6 +214,14 @@ def analyze_video_file(
         summary_path = summary.save(session_dir)
         if writer_enabled:
             writer.release()
+        from session.bad_rep_export import run_bad_rep_export
+        run_bad_rep_export(
+            session_dir,
+            analysed_video_path if writer_enabled else None,
+            summary,
+            fps,
+            source_video_path=video_path,
+        )
         detector.close()
         cap.release()
 

--- a/src/ui/overlay.py
+++ b/src/ui/overlay.py
@@ -283,22 +283,37 @@ class OverlayRenderer:
         frame_h, frame_w = frame_bgr.shape[:2]
         margin = 34
 
+        browser_hint = (
+            "Up/Down select  |  P play video  |  O open folder  |  H show invalid tests  |  Esc dashboard"
+            if hide_incomplete_sessions
+            else "Up/Down select  |  P play video  |  O open folder  |  H hide invalid tests  |  Esc dashboard"
+        )
         self._draw_screen_header(
             frame_bgr,
             margin,
             "Session Browser",
-            "Up/Down select  |  P play video  |  O open folder  |  H hide/show incomplete  |  Esc dashboard",
+            browser_hint,
         )
 
         list_x = margin
         list_y = 126
         list_w = frame_w - (margin * 2)
         list_h = frame_h - list_y - margin
-        status_x = list_x + list_w - 196
-        status_w = 150
-        bad_x = list_x + list_w - 318
-        reps_x = list_x + list_w - 440
         metric_w = 70
+        if hide_incomplete_sessions:
+            fps_w = 90
+            knee_w = 120
+            fps_x = list_x + list_w - 150
+            knee_x = list_x + list_w - 300
+            bad_x = list_x + list_w - 420
+            reps_x = list_x + list_w - 540
+            status_x = status_w = None
+        else:
+            status_x = list_x + list_w - 196
+            status_w = 150
+            bad_x = list_x + list_w - 318
+            reps_x = list_x + list_w - 440
+            knee_x = knee_w = fps_x = fps_w = None
         timestamp_w = max(260, reps_x - list_x - 56)
 
         self._draw_panel(
@@ -319,12 +334,12 @@ class OverlayRenderer:
                 list_y,
                 list_w,
                 (
-                    "No complete sessions shown"
+                    "No valid sessions shown"
                     if hide_incomplete_sessions
                     else "No saved sessions found"
                 ),
                 (
-                    "Press H to show incomplete sessions again."
+                    "Press H to show invalid tests too."
                     if hide_incomplete_sessions
                     else "Complete a workout session to populate this browser."
                 ),
@@ -339,9 +354,38 @@ class OverlayRenderer:
         self._put_text_centered(
             frame_bgr, "Bad", bad_x, header_y - 22, metric_w, 24, 0.52, self.MUTED
         )
-        self._put_text_centered(
-            frame_bgr, "Status", status_x, header_y - 22, status_w, 24, 0.52, self.MUTED
-        )
+        if hide_incomplete_sessions:
+            self._put_text_centered(
+                frame_bgr,
+                "Avg Knee",
+                knee_x,
+                header_y - 22,
+                knee_w,
+                24,
+                0.52,
+                self.MUTED,
+            )
+            self._put_text_centered(
+                frame_bgr,
+                "Avg FPS",
+                fps_x,
+                header_y - 22,
+                fps_w,
+                24,
+                0.52,
+                self.MUTED,
+            )
+        else:
+            self._put_text_centered(
+                frame_bgr,
+                "Status",
+                status_x,
+                header_y - 22,
+                status_w,
+                24,
+                0.52,
+                self.MUTED,
+            )
         cv2.line(
             frame_bgr,
             (list_x + 22, list_y + 58),
@@ -364,16 +408,13 @@ class OverlayRenderer:
             selected = idx == selected_index
             reps = "N/A" if item.rep_count is None else str(item.rep_count)
             bad = "N/A" if item.bad_rep_count is None else str(item.bad_rep_count)
+            avg_knee = self._format_angle(getattr(item, "avg_knee_angle", None))
+            avg_fps = self._format_fps(getattr(item, "avg_fps", None))
             is_valid = bool(
                 getattr(item, "valid_session", item.rep_count not in (None, 0))
             )
             status_text = "Complete" if is_valid else "Incomplete"
-            display_name = (
-                str(item.folder_name)
-                .replace(" (incomplete)", "")
-                .replace("(incomplete)", "")
-                .strip()
-            )
+            display_name = str(item.folder_name).strip()
             selected_fill = (82, 91, 33)
             selected_border = (150, 222, 104)
             selected_text = (252, 250, 248)
@@ -473,27 +514,49 @@ class OverlayRenderer:
                 0.62,
                 self.ERROR if bad not in ("0", "N/A") else metric_color,
             )
-            self._draw_panel(
-                frame_bgr,
-                status_x,
-                row_y - 25,
-                status_w,
-                28,
-                color=status_fill,
-                border_color=status_border,
-                alpha=0.96,
-                radius=14,
-            )
-            self._put_text_centered(
-                frame_bgr,
-                status_text,
-                status_x,
-                row_y - 25,
-                status_w,
-                28,
-                0.42,
-                status_color,
-            )
+            if hide_incomplete_sessions:
+                self._put_text_centered(
+                    frame_bgr,
+                    avg_knee,
+                    knee_x,
+                    row_y - 28,
+                    knee_w,
+                    row_h,
+                    0.56,
+                    metric_color,
+                )
+                self._put_text_centered(
+                    frame_bgr,
+                    avg_fps,
+                    fps_x,
+                    row_y - 28,
+                    fps_w,
+                    row_h,
+                    0.56,
+                    metric_color,
+                )
+            else:
+                self._draw_panel(
+                    frame_bgr,
+                    status_x,
+                    row_y - 25,
+                    status_w,
+                    28,
+                    color=status_fill,
+                    border_color=status_border,
+                    alpha=0.96,
+                    radius=14,
+                )
+                self._put_text_centered(
+                    frame_bgr,
+                    status_text,
+                    status_x,
+                    row_y - 25,
+                    status_w,
+                    28,
+                    0.42,
+                    status_color,
+                )
             row_y += 50
 
     def draw_analytics(self, frame_bgr, snapshot, calibration_profile=None) -> None:
@@ -855,11 +918,16 @@ class OverlayRenderer:
         frame_h, frame_w = frame_bgr.shape[:2]
         margin = 34
 
+        browser_hint = (
+            "H show invalid tests"
+            if getattr(settings, "hide_incomplete_sessions", False)
+            else "H hide invalid tests"
+        )
         self._draw_screen_header(
             frame_bgr,
             margin,
             "Settings",
-            "T toggle theme  |  K switch camera  |  H hide/show incomplete  |  R reset calibration  |  Esc dashboard",
+            f"T toggle theme  |  K switch camera  |  {browser_hint}  |  R reset calibration  |  Esc dashboard",
         )
 
         panel_x = margin
@@ -908,10 +976,16 @@ class OverlayRenderer:
             camera_options,
             include_index=True,
         )
+        hides_invalid_tests = getattr(settings, "hide_incomplete_sessions", False)
         browser_value = (
-            "Hiding incomplete"
-            if getattr(settings, "hide_incomplete_sessions", False)
-            else "Showing all sessions"
+            "Valid sessions only"
+            if hides_invalid_tests
+            else "Valid + invalid tests"
+        )
+        browser_helper = (
+            "Press H to show invalid tests"
+            if hides_invalid_tests
+            else "Press H to hide invalid tests"
         )
         calibration_value = (
             "Calibrated"
@@ -921,7 +995,7 @@ class OverlayRenderer:
         cards = [
             ("Theme", theme_value, "Press T to switch light/dark", self.PRIMARY),
             ("Camera", camera_value, "Press K to cycle sources", self.INFO),
-            ("Session Browser", browser_value, "Press H to toggle visibility", self.TEXT),
+            ("Session Browser", browser_value, browser_helper, self.TEXT),
             (
                 "Calibration",
                 calibration_value,

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -76,7 +76,7 @@ def test_session_browser_marks_incomplete_sessions_without_crashing(tmp_path) ->
     sessions = list_recent_sessions(tmp_path, limit=None)
 
     assert sessions[0].valid_session is False
-    assert sessions[0].folder_name.endswith("(incomplete)")
+    assert sessions[0].folder_name == "20260503_120000"
     assert sessions[1].valid_session is True
     assert sessions[1].folder_name == "20260502_120000"
 

--- a/tests/test_bad_rep_export.py
+++ b/tests/test_bad_rep_export.py
@@ -1,0 +1,191 @@
+"""Tests for bad-rep slow-motion clip export and chapter metadata generation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from session.bad_rep_export import build_ffmetadata_string, _embed_chapters
+from session.summary import SessionSummary
+
+
+# ---------------------------------------------------------------------------
+# 1. bad_rep_timestamps JSON structure
+# ---------------------------------------------------------------------------
+
+def test_bad_rep_timestamps_included_in_to_dict():
+    summary = SessionSummary(started_at=datetime(2026, 5, 15, 10, 0, 0))
+    summary.record_completed_rep(
+        rep_index=3,
+        timestamp=14.8,
+        start_timestamp=12.4,
+        is_bad=True,
+        issues=("too_shallow",),
+        min_knee_angle=112.5,
+        min_ankle_angle=None,
+        max_torso_angle=None,
+    )
+    data = summary.to_dict()
+    assert "bad_rep_timestamps" in data
+    assert data["bad_rep_timestamps"] == [
+        {"rep_number": 3, "issue": "too_shallow", "start_sec": 12.4, "end_sec": 14.8}
+    ]
+
+
+def test_bad_rep_timestamps_empty_when_no_bad_reps():
+    summary = SessionSummary(started_at=datetime(2026, 5, 15, 10, 0, 0))
+    summary.record_completed_rep(
+        rep_index=1,
+        timestamp=5.0,
+        start_timestamp=3.0,
+        is_bad=False,
+        issues=(),
+        min_knee_angle=98.0,
+        min_ankle_angle=None,
+        max_torso_angle=None,
+    )
+    data = summary.to_dict()
+    assert data["bad_rep_timestamps"] == []
+
+
+def test_ankle_control_rep_included_in_bad_rep_timestamps():
+    summary = SessionSummary(started_at=datetime(2026, 5, 15, 10, 0, 0))
+    summary.record_completed_rep(
+        rep_index=1, timestamp=8.0, start_timestamp=6.0,
+        is_bad=False, issues=("ankle_control",), min_knee_angle=95.0,
+        min_ankle_angle=175.0, max_torso_angle=None,
+    )
+    data = summary.to_dict()
+    assert len(data["bad_rep_timestamps"]) == 1
+    assert data["bad_rep_timestamps"][0]["issue"] == "ankle_control"
+
+
+def test_clean_rep_excluded_from_bad_rep_timestamps():
+    summary = SessionSummary(started_at=datetime(2026, 5, 15, 10, 0, 0))
+    summary.record_completed_rep(
+        rep_index=1, timestamp=8.0, start_timestamp=6.0,
+        is_bad=False, issues=(), min_knee_angle=95.0,
+        min_ankle_angle=None, max_torso_angle=None,
+    )
+    data = summary.to_dict()
+    assert data["bad_rep_timestamps"] == []
+
+
+def test_bad_rep_timestamps_only_includes_bad_reps():
+    summary = SessionSummary(started_at=datetime(2026, 5, 15, 10, 0, 0))
+    summary.record_completed_rep(
+        rep_index=1, timestamp=5.0, start_timestamp=3.0,
+        is_bad=False, issues=(), min_knee_angle=95.0,
+        min_ankle_angle=None, max_torso_angle=None,
+    )
+    summary.record_completed_rep(
+        rep_index=2, timestamp=12.0, start_timestamp=10.0,
+        is_bad=True, issues=("too_shallow",), min_knee_angle=115.0,
+        min_ankle_angle=None, max_torso_angle=None,
+    )
+    data = summary.to_dict()
+    assert len(data["bad_rep_timestamps"]) == 1
+    assert data["bad_rep_timestamps"][0]["rep_number"] == 2
+
+
+def test_start_timestamp_preserved_in_completed_reps():
+    summary = SessionSummary(started_at=datetime(2026, 5, 15, 10, 0, 0))
+    summary.record_completed_rep(
+        rep_index=1, timestamp=8.0, start_timestamp=6.5,
+        is_bad=True, issues=("too_shallow",), min_knee_angle=111.0,
+        min_ankle_angle=None, max_torso_angle=None,
+    )
+    data = summary.to_dict()
+    assert data["completed_reps"][0]["start_timestamp"] == 6.5
+
+
+# ---------------------------------------------------------------------------
+# 2. Chapter metadata string format
+# ---------------------------------------------------------------------------
+
+def test_build_ffmetadata_string_contains_header():
+    text = build_ffmetadata_string([])
+    assert text.startswith(";FFMETADATA1")
+
+
+def test_build_ffmetadata_string_chapter_fields():
+    chapters = [
+        (0, 60000, "Session Start"),
+        (12400, 14800, "Rep 3 — too_shallow"),
+        (60000, 60000, "Session End"),
+    ]
+    text = build_ffmetadata_string(chapters)
+    assert "[CHAPTER]" in text
+    assert "TIMEBASE=1/1000" in text
+    assert "START=12400" in text
+    assert "END=14800" in text
+    assert "title=Rep 3 — too_shallow" in text
+    assert "title=Session Start" in text
+    assert "title=Session End" in text
+
+
+def test_build_ffmetadata_string_chapter_count():
+    chapters = [
+        (0, 5000, "A"),
+        (5000, 10000, "B"),
+        (10000, 10000, "C"),
+    ]
+    text = build_ffmetadata_string(chapters)
+    assert text.count("[CHAPTER]") == 3
+
+
+# ---------------------------------------------------------------------------
+# 3. Slow-motion frame count calculation
+# ---------------------------------------------------------------------------
+
+def test_slow_clip_frame_count_logic():
+    """The written frame count should equal pre + 2*bad_rep + post."""
+    fps = 30.0
+    buffer = 2.0
+    rep_start, rep_end = 5.0, 7.0
+    clip_start = rep_start - buffer   # 3.0
+    clip_end = rep_end + buffer       # 9.0
+
+    clip_start_frame = int(clip_start * fps)   # 90
+    rep_start_frame  = int(rep_start  * fps)   # 150
+    rep_end_frame    = int(rep_end    * fps)    # 210
+    clip_end_frame   = int(clip_end   * fps)    # 270
+
+    written = 0
+    for fi in range(clip_start_frame, clip_end_frame + 1):
+        repeat = 2 if rep_start_frame <= fi < rep_end_frame else 1
+        written += repeat
+
+    pre_frames  = rep_start_frame - clip_start_frame          # 60
+    bad_frames  = rep_end_frame   - rep_start_frame           # 60
+    post_frames = clip_end_frame  - rep_end_frame + 1         # 61 (inclusive)
+    expected    = pre_frames + 2 * bad_frames + post_frames   # 60+120+61 = 241
+
+    assert written == expected
+
+
+def test_slow_clip_buffer_clamped_to_zero():
+    """When a bad rep starts at t=0 the pre-buffer should clamp to frame 0."""
+    fps = 30.0
+    clip_start = max(0.0, 0.0 - 2.0)   # clamped to 0
+    assert clip_start == 0.0
+    assert int(clip_start * fps) == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Graceful FFmpeg skip when not installed
+# ---------------------------------------------------------------------------
+
+def test_embed_chapters_no_ffmpeg_does_not_raise(monkeypatch, capsys):
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    _embed_chapters(Path("nonexistent.mp4"), [], 60.0)
+    captured = capsys.readouterr()
+    assert "FFmpeg not found" in captured.out
+
+
+def test_embed_chapters_no_ffmpeg_does_not_modify_file(monkeypatch, tmp_path):
+    dummy = tmp_path / "session.mp4"
+    dummy.write_bytes(b"fake")
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    _embed_chapters(dummy, [], 10.0)
+    assert dummy.read_bytes() == b"fake"

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -35,6 +35,9 @@ def test_app_settings_persist_and_normalize_values(tmp_path, monkeypatch) -> Non
     monkeypatch.setattr(user_profile, "PROFILE_DIR", tmp_path)
     monkeypatch.setattr(user_profile, "SETTINGS_FILE", tmp_path / "settings.json")
 
+    defaults = load_app_settings()
+    assert defaults.hide_incomplete_sessions is True
+
     saved = save_app_settings(
         AppSettings(theme="neon", hide_incomplete_sessions=True, camera_index=99)
     )


### PR DESCRIPTION
## Summary
Implements bad-repetition evidence export and updates all documentation 
to reflect the final system state.

## Changes
- `src/session/bad_rep_export.py` — slow-motion clip extraction and FFmpeg chapter embedding
- `tests/test_bad_rep_export.py` — 13 unit tests for export logic

### Feature: bad-rep export
- 0.25× speed clip per bad rep (too_shallow, ankle_control, torso_lean)
- 0.5 s pre/post buffer around each flagged rep
- Issue label and min knee angle overlaid on every frame
- Clips saved to `bad_reps/` subfolder in session directory
- FFmpeg chapter markers embedded in session MP4 if FFmpeg available
- Graceful fallback with console warning if FFmpeg absent
- `summary.json` gains `bad_rep_timestamps` array
- `rep_metrics.csv` gains `start_timestamp_seconds` column

### Pipeline wiring
- `squat.py`, `summary.py`, `video_analysis.py`, `app.py` updated to
  capture rep start times and trigger export after session end

### Tests
- 13 new tests added; 32 total, all passing, 0 warnings

### Documentation
- README rewritten: Python 3.10, all controls, thresholds, calibration,
  bad-rep export, optional FFmpeg, testing guide
- `docs/test-plan.md`: 180 cases, 92.2% pass rate, 32 pytest breakdown
- `docs/final-project-artifacts.md`: architecture updated
- `docs/evaluation/README.md`: covers live and offline session types
- `docs/evaluation/manual_labels.csv`: final 20-row evaluation dataset

Closes #64 